### PR TITLE
Footer now stacked on top of filters

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -405,6 +405,7 @@ h5 {
 	color: white;
 	margin-top: 50px;
 	padding-top: 40px;
+	position: relative;
 	/*padding-bottom: 20px;*/
 }
 


### PR DESCRIPTION
So the filter was stacked on top of the footer b/c the footer wasn't positioned (while the filters are). I set `position: relative` for the footer, and now it is stacked on top of the filters.

Here are before/after GIFs for the publications page.

*Before*
![footer-old](https://user-images.githubusercontent.com/6518824/34127741-3071cf6e-e40c-11e7-91ac-a6b128fcae75.gif)

*After*
![footer-new](https://user-images.githubusercontent.com/6518824/34127659-ee1fe68c-e40b-11e7-9884-a9b660d952fe.gif)

Resolves #286 