### PR TITLE
adding mapped config.ini, updated requirements and a debug log

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -73,6 +73,26 @@ else:
 #     },
 # }
 
+##DEBUG LOGGING FOR CSE SUPPORT SETUP
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': '/code/media/debug.log',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
 
 # Application definition
 

--- a/makeabilitylabwebsite/command
+++ b/makeabilitylabwebsite/command
@@ -3,5 +3,7 @@
 # Note: "example-container" should match the "container_name" value in the
 # config.php file
 #
-docker run -d --name=makeabilitylabwebsite -p 127.0.0.1:8571:8000 --restart=always -v /cse/web/research/makelab/www/:/code/media/ makeabilitylabwebsite
+docker run -d --name=makeabilitylabwebsite -p 127.0.0.1:8571:8000
+--restart=always -v /cse/web/research/makelab/www/:/code/media/ -v
+/cse/web/research/makelab/secret/config.ini:/code/config.ini makeabilitylabwebsite
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ xmltodict==0.10.2
 google-api-python-client==1.5.3
 pyOpenSSL
 requests
-
-
+psycopq2


### PR DESCRIPTION
debug log is now getting dumped to /cse/web/research/makelab/www/debug.log  which you should be able to get to from recycle.

If you want to stop, just  comment it out in settings.py