### PR TITLE
Landing page pub improvements

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -44,6 +44,12 @@ h5 {
 	margin-bottom:0;
 }
 
+.popover {
+	width: 50vw;
+    min-width: 300px;
+    max-width: 100vw;
+}
+
 .item-info {
 	margin:0;
 	padding-top:10px;

--- a/website/static/website/css/index.css
+++ b/website/static/website/css/index.css
@@ -88,6 +88,9 @@ Just playing around wit hover effects
     /*text-align: center;*/
 }
 
+.pub-thumbnail {
+    position: relative;
+}
 
 .pub-thumbnail-image {
 	border: 1px solid #dddddd;
@@ -126,6 +129,17 @@ Just playing around wit hover effects
     clip: rect(0px,200px,100px,0px);
     display: block;
     min-height:100px;
+}
+
+.pub-download-links {
+    font-size: 7pt;
+    color: gray;
+    margin: 0;
+    margin-left: 107px;
+    margin-right: 20px;
+    bottom: 0;
+    position: absolute;
+    border-top: 1px solid #dddddd;
 }
 
 .talk2-thumbnail{

--- a/website/static/website/css/publications.css
+++ b/website/static/website/css/publications.css
@@ -19,10 +19,6 @@
     width: 100%;
 }
 
-.popover {
-    max-width: 100%;
-}
-
 .citation-links {
     text-align: right;
     margin-bottom: -5px;

--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -1,0 +1,156 @@
+// Reusable citation popover module
+//
+// usage: $(citationLink).citationPopover(pub)
+//		pub: an object containing the publication data
+(function ($) {
+
+	$.fn.citationPopover = function (pub) {
+
+		// Hide popovers when clicking outside, but not when clicking inside
+		// from: http://stackoverflow.com/a/14857326
+		// LS: this is a bit of a hack, since the default click behavior leaves them open
+		// until you click on the button again, but the default focus behavior prevents you
+		// from interacting with the content of the popover
+		$('body').on('click', function (e) {
+		    $('[data-toggle="popover"]').each(function () {
+		        //the 'is' for buttons that trigger popups
+		        //the 'has' for icons within a button that triggers a popup
+		        if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+		            $(this).popover('hide');
+		        }
+		    });
+		});
+
+		this.attr("data-content", createCitationText(pub));
+
+		$(this).updateCitationPopover();
+
+		return this;
+	}
+
+	// combines and formats the citation metadata for display
+	function createCitationText(pub) {
+		var text = "<div class=\"citation-links\"><a id=\"citation-link\" onclick=\"$(this).citationclick()\">Citation</a> | <a id=\"bibtex-link\" onclick=\"$(this).bibtexclick()\">Bibtex</a></div><br/>";
+	    // authors
+	    text+="<div id=\"citation-text\">";
+		pub.authors.forEach(function(author, index, array) {
+			text += author.last_name + ", " + author.first_name.substring(0,1) + ". ";
+			if(author.middle_name && author.middle_name.length > 0)
+				text += author.middle_name.substring(0,1) + ". ";
+			text = text.substring(0, text.length-1) + ", "; // trim last space, add comma
+		});
+		if(text.length > 0) text = text.substring(0, text.length - 2); // trim last comma and space
+
+		// year
+		text += " (" + pub.date.getFullYear() + "). ";
+
+		// title
+		text += pub.title + ". ";
+
+		// venue
+		text += "<i>" + pub.venue + "</i>. "
+
+		// pages
+		if(pub.to_appear) {
+			if(pub.num_pages) {
+				text += pub.num_pages + " pages.";
+			}
+			text += " <i>To Appear</i>.";
+		} else if(pub.start_page && pub.end_page) {
+			text += pub.start_page + "&ndash;" + pub.end_page + ".";
+		}
+	    text+="</div>";
+	    text+="<div id=\"bibtex-text\" style=\"display: none\">";
+	    text+="@inproceedings{"+pub.authors[0].last_name+pub.series.split(" ")[0]+",<br/>";
+	    text+=" author = {";
+	    pub.authors.forEach(function(author, index, array){
+		text+=author.last_name+", "+author.first_name+" "+author.middle_name;
+		if (index != array.length-1){
+		    text+=" and ";
+		}
+	    });
+	    text+="},<br/>";
+	    text+=" title = {"+pub.title+"},<br/>";
+	    if(pub.book_title && pub.book_title!="None"){
+		text+=" book_title = {"+pub.book_title+"},<br/>";
+	    }
+	    text+=" book_title_short = {"+pub.venue+"},<br/>";
+	    if(pub.series && pub.series!="None"){
+		text+=" series = {"+pub.series+"},<br/>"; //Is this what series is?
+	    }
+	    text+=" year = {"+pub.date.getFullYear()+"},<br/>";
+	    if (pub.isbn && pub.isbn!="None" && pub.isbn!="tbd") {
+		text+=" isbn = {"+pub.isbn+"},<br/>";
+	    }
+	    if (pub.geo_location && pub.geo_location!="None") {
+		text+=" location = {"+pub.geo_location+"},<br/>";
+	    }
+	    if (pub.page_num_start && pub.page_num_start!="None") {
+		text+=" pages = {"+pub.page_num_start+"--"+pub.page_num_end+"},<br/>";
+		text+=" numpages = {"+String(parseInt(pub.page_num_end)-parseInt(pub.page_num_start))+"},<br/>";
+	    }
+	    if (pub.url && pub.url!="None" && pub.url!="tbd"){
+		text+=" url = {"+pub.url+"},<br/>";
+	    }
+	    if (pub.doi && pub.doi!="None" && pub.doi!="tbd"){
+		text+=" doi = {"+pub.doi+"},<br/>";
+	    }
+	    if (pub.acmid && pub.acmid!="None" && pub.acmid!="tbd"){
+		text+=" acmid = {"+pub.acmid+"},<br/>";
+	    }
+	    if (pub.publisher && pub.publisher!="None"){
+		text+=" publisher = {"+pub.publisher+"},<br/>";
+		text+=" publisher_address = {"+pub.publisher_address+"},<br/>";
+	    }
+	    if (pub.award && pub.award!="None"){
+		text+=" award = {"+pub.award+"},<br/>";
+	    }
+	    if (pub.total_papers_accepted && pub.total_papers_accepted!="None") {
+		text+=" total_papers_submitted = {"+pub.total_papers_submitted+"},<br/>";
+		text+=" total_papers_accepted = {"+pub.total_papers_accepted+"},<br/>";
+	    }
+	    if (pub.video_url && pub.video_url!="None"){
+		text+=" video_url = {"+pub.video_url+"},<br/>";
+	    }
+	    text+=" keywords = {";
+	    pub.keywords.forEach(function(keyword, index, array){
+		text+=keyword;
+		if (index != array.length-1) {
+		    text+=", "; 
+		}
+	    });
+	    text+="}<br/>}"
+	    text+="</div>";
+
+		return text;
+	}
+
+	$.fn.citationclick = function() {
+		$("#citation-text").css('display', 'block');
+		$("#bibtex-text").css('display', 'none');
+	}
+
+	$.fn.bibtexclick = function() {
+		$("#bibtex-text").css('display', 'block');
+		$("#citation-text").css('display', 'none');
+	}
+
+	$.fn.updateCitationPopover = function() {
+		$(this).popover()
+
+		// Manual trigger to get around idiosyncrasies of bootstrap's popover control
+		$(this).click(function() {
+
+			// prevent multiple popovers from being open at once
+			var popovers = $('[data-toggle="popover"]')
+			for(var i = 0; i < popovers.length; i++) {
+				if(popovers[i] != this) // ignore the current popover
+					$(popovers[i]).popover('hide');
+			}
+
+			// toggle this popover
+			$(this).popover('toggle');
+		});
+	}
+
+}(jQuery));

--- a/website/static/website/js/publications.js
+++ b/website/static/website/js/publications.js
@@ -26,35 +26,9 @@ var pubTypeCodes = {
 // initialization code that's called when the window has finished loading
 $(window).load(function () {
 
-    $("#citation-link").click(function(){
-	console.log("citation clicked");
-	$("#citation-text").css('display', 'block');
-	$("#bibtex-text").css('display', 'none');
-    });
-    $("#bibtex-link").click(function(){
-	console.log("bibtex clicked");
-	$("#bibtex-text").css('display', 'block');
-	$("#citation-text").css('display', 'none');
-    });
-
 	// preserve the template designs so that they're not lost when updating the display
 	groupTemplate = $(".group-template").clone();
 	publicationTemplate = $(".publication-template").clone();
-
-	// Hide popovers when clicking outside, but not when clicking inside
-	// from: http://stackoverflow.com/a/14857326
-	// LS: this is a bit of a hack, since the default click behavior leaves them open
-	// until you click on the button again, but the default focus behavior prevents you
-	// from interacting with the content of the popover
-	$('body').on('click', function (e) {
-	    $('[data-toggle="popover"]').each(function () {
-	        //the 'is' for buttons that trigger popups
-	        //the 'has' for icons within a button that triggers a popup
-	        if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
-	            $(this).popover('hide');
-	        }
-	    });
-	});
 
 	// initialize the filter bar module with the publication data
 	preprocessPublications();
@@ -330,133 +304,13 @@ function formatPublication(pub, filter) {
     else {
         publicationData.find(".publication-video-link-label").css("display", "none");
     }
-    publicationData.find(".publication-citation-link").attr("data-content", createCitationText(pub));
+    // publicationData.find(".publication-citation-link").attr("data-content", createCitationText(pub));
+    publicationData.find(".publication-citation-link").citationPopover(pub);
 
 	return publicationData[0].outerHTML;
 }
 
 // called after initialization or whenever the filter is reapplied
 function afterDisplay() {
-	$('[data-toggle="popover"]').popover()
-
-	// Manual trigger to get around idiosyncrasies of bootstrap's popover control
-	$('[data-toggle="popover"]').click(function() {
-
-		// prevent multiple popovers from being open at once
-		var popovers = $('[data-toggle="popover"]')
-		for(var i = 0; i < popovers.length; i++) {
-			if(popovers[i] != this) // ignore the current popover
-				$(popovers[i]).popover('hide');
-		}
-
-		// toggle this popover
-		$(this).popover('toggle');
-	});
+	$('[data-toggle="popover"]').updateCitationPopover();
 }
-
-function citationclick(){
-    $("#citation-text").css('display', 'block');
-    $("#bibtex-text").css('display', 'none');
-}
-function bibtexclick(){
-    $("#bibtex-text").css('display', 'block');
-    $("#citation-text").css('display', 'none');
-}
-
-// combines and formats the citation metadata for display
-function createCitationText(pub) {
-	var text = "<div class=\"citation-links\"><a id=\"citation-link\" onclick=\"citationclick()\">Citation</a> | <a id=\"bibtex-link\" onclick=\"bibtexclick()\">Bibtex</a></div><br/>";
-    // authors
-    text+="<div id=\"citation-text\">";
-	pub.authors.forEach(function(author, index, array) {
-		text += author.last_name + ", " + author.first_name.substring(0,1) + ". ";
-		if(author.middle_name && author.middle_name.length > 0)
-			text += author.middle_name.substring(0,1) + ". ";
-		text = text.substring(0, text.length-1) + ", "; // trim last space, add comma
-	});
-	if(text.length > 0) text = text.substring(0, text.length - 2); // trim last comma and space
-
-	// year
-	text += " (" + pub.date.getFullYear() + "). ";
-
-	// title
-	text += pub.title + ". ";
-
-	// venue
-	text += "<i>" + pub.venue + "</i>. "
-
-	// pages
-	if(pub.to_appear) {
-		if(pub.num_pages) {
-			text += pub.num_pages + " pages.";
-		}
-		text += " <i>To Appear</i>.";
-	} else if(pub.start_page && pub.end_page) {
-		text += pub.start_page + "&ndash;" + pub.end_page + ".";
-	}
-    text+="</div>";
-    text+="<div id=\"bibtex-text\" style=\"display: none\">";
-    text+="@inproceedings{"+pub.authors[0].last_name+pub.series.split(" ")[0]+",<br/>";
-    text+=" author = {";
-    pub.authors.forEach(function(author, index, array){
-	text+=author.last_name+", "+author.first_name+" "+author.middle_name;
-	if (index != array.length-1){
-	    text+=" and ";
-	}
-    });
-    text+="},<br/>";
-    text+=" title = {"+pub.title+"},<br/>";
-    if(pub.book_title && pub.book_title!="None"){
-	text+=" book_title = {"+pub.book_title+"},<br/>";
-    }
-    text+=" book_title_short = {"+pub.venue+"},<br/>";
-    if(pub.series && pub.series!="None"){
-	text+=" series = {"+pub.series+"},<br/>"; //Is this what series is?
-    }
-    text+=" year = {"+pub.date.getFullYear()+"},<br/>";
-    if (pub.isbn && pub.isbn!="None" && pub.isbn!="tbd") {
-	text+=" isbn = {"+pub.isbn+"},<br/>";
-    }
-    if (pub.geo_location && pub.geo_location!="None") {
-	text+=" location = {"+pub.geo_location+"},<br/>";
-    }
-    if (pub.page_num_start && pub.page_num_start!="None") {
-	text+=" pages = {"+pub.page_num_start+"--"+pub.page_num_end+"},<br/>";
-	text+=" numpages = {"+String(parseInt(pub.page_num_end)-parseInt(pub.page_num_start))+"},<br/>";
-    }
-    if (pub.url && pub.url!="None" && pub.url!="tbd"){
-	text+=" url = {"+pub.url+"},<br/>";
-    }
-    if (pub.doi && pub.doi!="None" && pub.doi!="tbd"){
-	text+=" doi = {"+pub.doi+"},<br/>";
-    }
-    if (pub.acmid && pub.acmid!="None" && pub.acmid!="tbd"){
-	text+=" acmid = {"+pub.acmid+"},<br/>";
-    }
-    if (pub.publisher && pub.publisher!="None"){
-	text+=" publisher = {"+pub.publisher+"},<br/>";
-	text+=" publisher_address = {"+pub.publisher_address+"},<br/>";
-    }
-    if (pub.award && pub.award!="None"){
-	text+=" award = {"+pub.award+"},<br/>";
-    }
-    if (pub.total_papers_accepted && pub.total_papers_accepted!="None") {
-	text+=" total_papers_submitted = {"+pub.total_papers_submitted+"},<br/>";
-	text+=" total_papers_accepted = {"+pub.total_papers_accepted+"},<br/>";
-    }
-    if (pub.video_url && pub.video_url!="None"){
-	text+=" video_url = {"+pub.video_url+"},<br/>";
-    }
-    text+=" keywords = {";
-    pub.keywords.forEach(function(keyword, index, array){
-	text+=keyword;
-	if (index != array.length-1) {
-	    text+=", "; 
-	}
-    });
-    text+="}<br/>}"
-    text+="</div>";
-
-	return text;
-}
-

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -8,7 +8,110 @@
 
 {% block stylesheets %}
     <link rel="stylesheet" href="{% static 'website/css/index.css' %}">
+    <link rel="stylesheet" href="{% static 'website/css/publications.css' %}">
     <link rel="stylesheet" href="{% static 'website/css/bootstrap-modifications.css' %}">
+{% endblock %}
+
+{% block external_scripts %}
+
+<script src="{% static 'website/js/jquery-ui.min.js' %}"></script>
+<script src="{% static 'website/js/citationPopover.js' %}"></script>
+
+{% endblock %}
+
+{% block scripts %}
+
+    // TODO: move these scripts into a separate file
+    $(document).ready(function() {
+
+        // find the citation links and set up the popover content and behavior for each
+        var citationLinks = $(".publication-citation-link");
+        for(var i = 0; i < citationLinks.length; i++) {
+            $(citationLinks[i]).citationPopover(publications[i]);
+        }
+
+        // update the publication awards
+        var publicationItems = $(".pub-column");
+        for(var i = 0; i < publicationItems.length; i++) {
+            var pub = publications[i];
+            var publicationData = publicationItems[i];
+            if (pub.award) {
+                var award_icon;
+                if (pub.award == "Best Paper Award") {
+                    award_icon = pub.best_paper;
+                } else {
+                    award_icon = pub.honorable_mention;
+                }
+
+                $(publicationData).find(".publication-award-icon").append("<img src=\"" + award_icon + "\" align=\"center\" class=\"award-icon\"/>");
+                $(publicationData).find(".pub-thumbnail-link").append("<img src=\"" + pub.award_banner + "\" class=\"publication-award-banner\"/>");
+                $(publicationData).find(".publication-award-text").html(pub.award);
+            } else {
+                $(publicationData).find(".publication-award").css("display", "none");
+            }
+        }
+    });
+
+    // get the publication data for filling the citations
+    // TODO: is there a way to integrate this into the HTML/Django code below?
+    var publications = [
+        {% for pub in publications|slice:"6" %}
+        {
+            "id": "A.###",
+            "title": "{{ pub.get_title }}",
+            "authors": [
+            {% for author in pub.authors.all %}
+                {
+                "name": "{{ author.get_full_name }}",
+                "first_name": "{{ author.first_name }}",
+                "middle_name": "{{ author.middle_name }}",
+                "last_name": "{{ author.last_name }}",
+                "link": "{% url 'website:member' author.id %}"
+                },
+            {% endfor %}
+            ],
+            "date": new Date("{{ pub.date }}"),
+            "pdf": "../../media/{{ pub.pdf_file }}",
+            "video_url": "{{ pub.video.video_url }}",
+            "thumbnail": "{% thumbnail pub.thumbnail 300x0 detail %}",
+            "venue": "{{ pub.book_title_short }}",
+            "pub_type": "{{ pub.pub_venue_type }}",
+            "geo_location": "{{ pub.geo_location }}",
+            "series": "{{ pub.series }}",
+            "page_num_start": "{{ pub.page_num_start }}",
+            "page_num_end": "{{ pub.page_num_end }}",
+            "book_title": "{{ pub.book_title }}",
+            "url": "{{ pub.official_url }}",
+            "doi": "{{ pub.doi }}",
+            "publisher": "{{ pub.publisher }}",
+            "publisher_address": "{{ pub.publisher_address }}",
+            "isbn": "{{ pub.isbn }}",
+            "best_paper": "{% static 'website/img/bestpaper.png' %}",
+            "honorable_mention": "{% static 'website/img/honorablemention.png' %}",
+            "award_banner": "{% static 'website/img/awardoverlay.png' %}",
+            {% if pub.award %}"award": "{{ pub.award }}",{% endif %}
+            {% if pub.total_papers_accepted and pub.total_papers_submitted %}
+                "total_papers_accepted": {{ pub.total_papers_accepted }},
+                "total_papers_submitted": {{ pub.total_papers_submitted }},
+            {% endif %}
+            {% if pub.page_num_start %} "start_page": {{ pub.page_num_start }},{% endif %}
+            {% if pub.page_num_end %} "end_page": {{ pub.page_num_end }},{% endif %}
+            {% if pub.num_pages %} "num_pages": {{ pub.num_pages }},{% endif %}
+            "to_appear": {% if pub.to_appear %}true{% else %}false{% endif %},
+            "keywords": [
+                {% for keyword in pub.keywords.all %}
+                    "{{ keyword.keyword }}",
+                {% endfor %}
+            ],
+            "projects": [
+                {% for project in pub.projects.all %}
+                    "{{ project.short_name }}",
+                {% endfor %}
+            ]
+        },
+        {% endfor %}
+    ];
+
 {% endblock %}
 
 <!-- TODO: In general, I need to test on and support mobile devices. I just tested it and it looks weird. Also need to test on other browsers -->
@@ -131,13 +234,14 @@
                     <a href="../../media/{{ pub.pdf_file }}">
                         <span class="artifact-title line-clamp" style="margin-top: 0px;">{{ pub.title }}</span>
                     </a>
-                    <p class="artifact-venue">
+                    <p class="artifact-venue line-clamp-one-line">
                         {{ pub.book_title_short }}
                         {% if pub.to_appear %}
                             <span class="pub-to-appear-text">To Appear</span>
                         {% endif %}
+                        <span class="publication-award">| <span class="publication-award-text">{{ pub.award }}</span> <span class="publication-award-icon"><i class=\"fa fa-trophy\" aria-hidden="true"></i></span></span>
                     </p>
-                    <p class="artifact-authors">
+                    <p class="artifact-authors line-clamp3">
                         {% for author in pub.authors.all %}
                             <a href="{% url 'website:member' author.id %}">{{author.get_full_name}}</a>{% if not forloop.last %},{% endif %}
                         {% endfor %}
@@ -149,11 +253,10 @@
                     <!-- We only show the download bar if there is a paper to download. And, thankfully, this if condition checks that
                          pub.pdf_file exists, is not empty, and is not a false boolean value. See https://docs.djangoproject.com/en/1.9/ref/templates/builtins/#if-->
                     {% if pub.pdf_file %}
-                        <!-- TODO: don't use an inline style--actually make a style for this -->
-                        <p style="font-size: 7pt; color: gray; margin: 0; padding-left:107px; bottom: 0; position: absolute; border-top: 1px solid #dddddd;">
+                        <p class="pub-download-links">
                             <a href="../../media/{{ pub.pdf_file }}">PDF</a>
                             {% if pub.official_url %}<a href="{{ pub.official_url }}">| Official Link</a> |{% endif %}
-                            | Citation <!-- TODO: hook up this citation link and have a pop-over like publications.html page -->
+                            | <a data-toggle="popover" data-html="true" data-trigger="manual" tabindex="0" title="Citation" data-content="Empty Citation" class="publication-citation-link">Citation</a>
                             {% if pub.talk.pdf_file %}<a href="../../media/{{ pub.talk.pdf_file }}">| Talk</a>{% endif %}
                         </p>
                     {% endif %}

--- a/website/templates/website/publications.html
+++ b/website/templates/website/publications.html
@@ -24,6 +24,7 @@
 <script src="{% static 'website/js/filterBar.js' %}"></script>
 <script src="{% static 'website/js/publications.js' %}"></script>
 <script src="{% static 'website/js/jquery-ui.min.js' %}"></script>
+<script src="{% static 'website/js/citationPopover.js' %}"></script>
 
 
 


### PR DESCRIPTION
Created a reusable citationPopover jQuery object, and updated both the publications and landing pages to use it.

Capped the venue info to one line and the authors to three lines to avoid overflow.

Fixed formatting of the gray border separating the download links.

Added best paper icons, etc. to the landing page.