### PR TITLE
Videos sorted by Project are chronological

### DIFF
--- a/website/static/website/js/videos.js
+++ b/website/static/website/js/videos.js
@@ -69,9 +69,12 @@ function groupVideosByYear()
 // to be more like talks.js
 function groupVideosByProject()
 {
+	// tempGroups holds all videos that are contained under the same project
 	var tempGroups = {};
+
 	videos.forEach(function(video, index, array) {
 		group = video.project_short_name;
+		// console.log("Video: " + video.title + ", Date: " + video.date.toString());
 		if(!(group in tempGroups)) {
 			tempGroups[group] = [];
 		}
@@ -80,11 +83,13 @@ function groupVideosByProject()
 
 	var groups = []
 	for(group in tempGroups) {
+		tempGroups[group].sort(function(a, b) { return b.date - a.date});
+		// project name, all videos associated with the project
 		groups.push({"name": group, "items": tempGroups[group]});
 	}
 
-	// years are sorted chronologically, all of the other groupings are sorted by frequency
-	groups.sort(function(a,b) { return b.items.length - a.items.length });
+	// groupings are done by the date of the most recent video from each project
+	groups.sort(function(a,b) { return b.items[0].date - a.items[0].date });
 
 	return groups;
 }


### PR DESCRIPTION
Addresses issue #276 

Sorting is both within the projects and between projects. (Videos with most recent projects come first, most recent videos for each project are listed first)

![image](https://user-images.githubusercontent.com/25534091/40450590-03ca2ab0-5e91-11e8-85d3-5279bf6c2af7.png)

There were some problems with updating .js files with Docker, so I had to modify the run command to this in order to get the website to update correctly. Might be nice to look into this later? (new potential issue?)

New command:
```
docker run -p 8000:8000 -ti -v database:/code/db -v $(pwd)/media:/code/media -v $(pwd)/website/static/website:/code/website/static/website [tag]
```