### PR TITLE
Made user urls friendlier so that people can be referenced by names

### DIFF
--- a/website/admin.py
+++ b/website/admin.py
@@ -98,6 +98,7 @@ class PersonAdmin(ImageCroppingMixin, admin.ModelAdmin):
     #https://www.elements.nl/2015/03/16/getting-the-most-out-of-django-admin-filters/
     #related to: https://github.com/jonfroehlich/makeabilitylabwebsite/issues/238
     list_filter = (CurrentMemberListFilter, PositionListFilter)
+    prepopulated_fields = {'url_name':('first_name', 'last_name',)}
 
 class VideoAdmin(admin.ModelAdmin):
     # The list display lets us control what is shown in the default persons table at Home > Website > Videos

--- a/website/models.py
+++ b/website/models.py
@@ -7,6 +7,7 @@ from datetime import date
 from datetime import timedelta
 from website.utils.fileutils import UniquePathAndRename
 import os
+import re
 from random import choice
 from django.core.files import File
 
@@ -30,6 +31,12 @@ class Person(models.Model):
     first_name = models.CharField(max_length=40)
     middle_name = models.CharField(max_length=50, blank=True, null=True)
     last_name = models.CharField(max_length=50)
+
+    # TODO: Need to figure out how to make this not add the em-dash when autocompleted
+    # URL Name for this person generated from the first and last names
+    # Default: Jon E Froehlich --> jon-froehlich
+    url_name = models.CharField(max_length=50, blank=True, null=True)
+    url_name.help_text = "This field will give you the location of your profile. Your profile will be located at member/url_name"
     email = models.EmailField(blank=True, null=True)
     personal_website = models.URLField(blank=True, null=True)
     github = models.URLField(blank=True, null=True)

--- a/website/urls.py
+++ b/website/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^people/$', views.people, name='people'),
     url(r'^member/(?P<member_id>[0-9]+)/$', views.member, name='member'),
+    url(r'^member/(?P<member_id>[-a-z]+)/$', views.member, name='member'),
     url(r'^publications/$', views.publications, name='publications'),
     url(r'^talks/$', views.talks, name='talks'),
     url(r'^videos/$', views.videos, name='videos'),

--- a/website/views.py
+++ b/website/views.py
@@ -213,25 +213,28 @@ def people(request):
 
 
 def member(request, member_id):
-   # try:
-   #     person = Person.objects.get(pk=member_id)
-   # except Person.DoesNotExist:
-   #     raise Http404("Person does not exist")
-   # return render(request, 'website/member.html', {'person': person})
-   news_items_num = 5 # Defines the number of news items that will be selected
-   all_banners = Banner.objects.filter(page=Banner.PEOPLE)
-   displayed_banners = choose_banners(all_banners)
-   person = get_object_or_404(Person, pk=member_id)
-   news = person.news_set.order_by('-date')[:news_items_num]
-   publications = person.publication_set.order_by('-date')
-   talks = person.talk_set.order_by('-date')
-   context = { 'person': person,
-               'news': news,
-               'talks': talks,
-               'publications': publications,
-               'banners': displayed_banners,
-               'debug': settings.DEBUG }
-   return render(request, 'website/member.html', context)
+    # try:
+    #     person = Person.objects.get(pk=member_id)
+    # except Person.DoesNotExist:
+    #     raise Http404("Person does not exist")
+    # return render(request, 'website/member.html', {'person': person})
+    news_items_num = 5 # Defines the number of news items that will be selected
+    all_banners = Banner.objects.filter(page=Banner.PEOPLE)
+    displayed_banners = choose_banners(all_banners)
+    if (member_id.isdigit()):
+        person = get_object_or_404(Person, pk=member_id)
+    else:
+        person = get_object_or_404(Person, url_name__iexact=member_id)
+    news = person.news_set.order_by('-date')[:news_items_num]
+    publications = person.publication_set.order_by('-date')
+    talks = person.talk_set.order_by('-date')
+    context = { 'person': person,
+                'news': news,
+                'talks': talks,
+                'publications': publications,
+                'banners': displayed_banners,
+                'debug': settings.DEBUG }
+    return render(request, 'website/member.html', context)
 
 def publications(request):
     all_banners = Banner.objects.filter(page=Banner.PUBLICATIONS)


### PR DESCRIPTION
Addresses issue #121 

Users URLs can now look like this (this is based off the Url Name field in `models.py`): 
![image](https://user-images.githubusercontent.com/25534091/40559431-982af74a-600b-11e8-9252-441e43e570df.png)

Users can be found either through their member ID or their url name. Links to users are all currently through the Member IDs still (going to open up a separate issue for this)

The URL Name field is filled out as you're typing and defaults to a firstname-lastname format. I'm not sure how to get rid of the hyphen, so that might be something to look into since the format isn't perfect. This field can also be edited manually.

It also doesn't automatically generate for existing members.

![image](https://user-images.githubusercontent.com/25534091/40559413-8a76200c-600b-11e8-9bb6-b626a756f502.png)


