### PR TITLE
Errant Commas addressed in People Listing

### DIFF
--- a/website/templates/website/people.html
+++ b/website/templates/website/people.html
@@ -85,7 +85,7 @@
             {{ active_prof|length }} Prof
             {% if active_postdoc or active_phd or active_ms%}, {% endif %}
             {% if active_postdoc %} {{ active_postdoc|length }} Postdoc{% endif %}
-            {% if active_phd or active_ms%}, {% endif %}
+            {% if active_postdoc %}, {% endif %}
             {% if active_phd %} {{ active_phd|length }} PhD{% endif %}
             {% if active_ms%}, {% endif %}
             {% if active_ms %} {{ active_ms|length }} MS{% endif %}


### PR DESCRIPTION
I believe that the issue found with the errant commas lies in fact that the active_phd passes both tests on lines 86 and 88 which causes two commas to be printed even though active_postdoc is false. I changed it so that the comma should only be printed if active_postdoc is true.