### PR TITLE
Resolves #260, #262, #363: Hides future project members + collaborators

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -349,15 +349,21 @@ class Position(models.Model):
 
     # Returns true if member is current based on end date
     def is_current_collaborator(self):
-        # print('Checkpoint 2: ' + self.person.get_full_name() + ' is collaborator? ' + str(self.is_collaborator()))
-
         return self.is_collaborator() and \
                (self.start_date is not None and self.start_date <= date.today() and \
                self.end_date is None or (self.end_date is not None and self.end_date >= date.today()))
 
-    # Returns true if member is an alumni member
+    # Returns true if member is an alumni member (used to differentiate between future members)
     def is_alumni_member(self):
-        return self.is_member() and self.end_date != None and self.end_date < date.today()
+        return self.is_member() and \
+               self.start_date < date.today() and \
+               self.end_date != None and self.end_date < date.today()
+
+    # Returns true if collaborator is a past collaborator (used to differentiate between future collaborators)
+    def is_past_collaborator(self):
+        return self.is_collaborator() and \
+               self.start_date < date.today() and \
+               self.end_date != None and self.end_date < date.today()
 
     def __str__(self):
         return "Name={}, Role={}, Title={}".format(self.person.get_full_name(), self.role, self.title)
@@ -492,7 +498,14 @@ class Project_Role(models.Model):
             return "{}-{}".format(self.start_date.year, self.end_date.year)
         
     def is_active(self):
-        return self.start_date is not None and self.start_date <= date.today() and self.end_date is None or (self.end_date is not None and self.end_date >= date.today())
+        return self.start_date is not None and self.start_date <= date.today() and \
+               (self.end_date is None or self.end_date >= date.today())
+
+    # This function is used to differentiate between past and future roles
+    def is_past(self):
+        return self.start_date is not None and self.start_date < date.today() and \
+               (self.end_date is not None and self.end_date < date.today())
+
 
     def __str__(self):
         return "Name={}, PI/Co-PI={}".format(self.person.get_full_name(), self.pi_member)

--- a/website/views.py
+++ b/website/views.py
@@ -8,23 +8,24 @@ from datetime import date
 
 # from . import googleanalytics
 
-max_banners = 7 # TODO: figure out best way to specify these settings... like, is it good to have them up here?
-filter_all_pubs_prior_to_date = datetime.date(2012, 1, 1) # Date Makeability Lab was formed
+max_banners = 7  # TODO: figure out best way to specify these settings... like, is it good to have them up here?
+filter_all_pubs_prior_to_date = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 
-#Every view is passed settings.DEBUG. This is used to insert the appropriate google analytics tracking when in
+
+# Every view is passed settings.DEBUG. This is used to insert the appropriate google analytics tracking when in
 # production, and to not include it for development
- 
+
 def index(request):
-    news_items_num = 7 # Defines the number of news items that will be selected
-    papers_num = 10 # Defines the number of papers which will be selected
-    talks_num = 8 # Defines the number of talks which will be selected
-    videos_num = 4 # Defines the number of videos which will be selected
-    projects_num = 3 # Defines the number of projects which will be selected
+    news_items_num = 7  # Defines the number of news items that will be selected
+    papers_num = 10  # Defines the number of papers which will be selected
+    talks_num = 8  # Defines the number of talks which will be selected
+    videos_num = 4  # Defines the number of videos which will be selected
+    projects_num = 3  # Defines the number of projects which will be selected
 
     all_banners = Banner.objects.filter(page=Banner.FRONTPAGE)
     displayed_banners = choose_banners(all_banners)
     print(settings.DEBUG)
-    #Select recent news, papers, and talks.
+    # Select recent news, papers, and talks.
     news_items = News.objects.order_by('-date')[:news_items_num]
     publications = Publication.objects.order_by('-date')[:papers_num]
     talks = Talk.objects.order_by('-date')[:talks_num]
@@ -42,16 +43,17 @@ def index(request):
     projects = Project.objects.all()
     projects = get_most_recent(projects);
 
-    context = { 'people': Person.objects.all(),
-                'banners': displayed_banners,
-                'news': news_items,
-                'publications': publications,
-                'talks': talks,
-                'videos':videos,
-                'projects': projects,
-                'debug': settings.DEBUG }
+    context = {'people': Person.objects.all(),
+               'banners': displayed_banners,
+               'news': news_items,
+               'publications': publications,
+               'talks': talks,
+               'videos': videos,
+               'projects': projects,
+               'debug': settings.DEBUG}
 
     return render(request, 'website/index.html', context)
+
 
 def people(request):
     # template = loader.get_template('website/people.html')
@@ -95,25 +97,26 @@ def people(request):
             elif position.title == Position.HIGH_SCHOOL:
                 active_highschool.append(position)
         elif position.is_alumni_member():
-           if position.is_professor() or position.is_grad_student():
-              if position.is_professor():
-                 alumni_prof.append(position)
-              elif position.title == Position.POST_DOC:
-                 alumni_postdoc.append(position)
-              elif position.title == Position.PHD_STUDENT:
-                 alumni_phd.append(position)
-              elif position.title == Position.MS_STUDENT:
-                 alumni_ms.append(position)
-           elif position.title == Position.UGRAD:
-              alumni_undergrad.append(position)
-           elif position.title == Position.HIGH_SCHOOL:
-              alumni_highschool.append(position)
+            if position.is_professor() or position.is_grad_student():
+                if position.is_professor():
+                    alumni_prof.append(position)
+                elif position.title == Position.POST_DOC:
+                    alumni_postdoc.append(position)
+                elif position.title == Position.PHD_STUDENT:
+                    alumni_phd.append(position)
+                elif position.title == Position.MS_STUDENT:
+                    alumni_ms.append(position)
+            elif position.title == Position.UGRAD:
+                alumni_undergrad.append(position)
+            elif position.title == Position.HIGH_SCHOOL:
+                alumni_highschool.append(position)
         elif position.is_collaborator():
             if position.is_current_collaborator():
                 cur_collaborators.append(position)
             else:
-                past_collaborators.append(position)
-    
+                if position.is_past_collaborator():
+                    past_collaborators.append(position)
+
     # sort active members/collaborators by seniority, and alumni/past 
     # collaborators by end data (most recent first)
     active_prof.sort(key=operator.attrgetter('start_date'))
@@ -149,64 +152,64 @@ def people(request):
     alumni_prof_grad.extend(alumni_postdoc)
     alumni_prof_grad.extend(alumni_phd)
     alumni_prof_grad.extend(alumni_ms)
-   
-    seen = [] 
+
+    seen = []
     for member in alumni_prof_grad:
-       if member.person in seen:
-           alumni_prof_grad.remove(member)
-       else:
-          seen.append(member.person)
+        if member.person in seen:
+            alumni_prof_grad.remove(member)
+        else:
+            seen.append(member.person)
 
-    seen = [] 
+    seen = []
     for member in alumni_undergrad:
-       if member.person in seen:
-           alumni_undergrad.remove(member)
-       else:
-          seen.append(member.person)
+        if member.person in seen:
+            alumni_undergrad.remove(member)
+        else:
+            seen.append(member.person)
 
-    seen = [] 
+    seen = []
     for member in alumni_highschool:
-       if member.person in seen:
-          alumni_highschool.remove(member)
-       else:
-          seen.append(member.person)
-    
+        if member.person in seen:
+            alumni_highschool.remove(member)
+        else:
+            seen.append(member.person)
+
     alumni_members.extend(alumni_prof_grad)
     alumni_members.extend(alumni_undergrad)
     alumni_members.extend(alumni_highschool)
 
     seen = []
     for member in alumni_members:
-       if member.person in seen:
-          alumni_members.remove(member)
-       else:
-          seen.append(member.person)
+        if member.person in seen:
+            alumni_members.remove(member)
+        else:
+            seen.append(member.person)
 
     all_banners = Banner.objects.filter(page=Banner.PEOPLE)
     displayed_banners = choose_banners(all_banners)
 
     context = {
-        'people' : Person.objects.all(),
-        'active_members' : active_members,
-        'active_prof_grad' : active_prof_grad,
-        'active_prof' : active_prof,
-        'active_postdoc' : active_postdoc,
-        'active_phd' : active_phd,
-        'active_ms' : active_ms,
-        'active_undergrad' : active_undergrad,
-        'active_highschool' : active_highschool,
-        'alumni_members' : alumni_members,
+        'people': Person.objects.all(),
+        'active_members': active_members,
+        'active_prof_grad': active_prof_grad,
+        'active_prof': active_prof,
+        'active_postdoc': active_postdoc,
+        'active_phd': active_phd,
+        'active_ms': active_ms,
+        'active_undergrad': active_undergrad,
+        'active_highschool': active_highschool,
+        'alumni_members': alumni_members,
         'alumni_prof_grad': alumni_prof_grad,
-        'alumni_prof' : alumni_prof,
-        'alumni_postdoc' : alumni_postdoc,
-        'alumni_phd' : alumni_phd,
-        'alumni_ms' : alumni_ms,
-        'alumni_undergrad' : alumni_undergrad,
-        'alumni_highschool' : alumni_highschool,
-        'cur_collaborators' : cur_collaborators,
-        'past_collaborators' : past_collaborators,
-        'positions' : positions,
-        'banners' : displayed_banners,
+        'alumni_prof': alumni_prof,
+        'alumni_postdoc': alumni_postdoc,
+        'alumni_phd': alumni_phd,
+        'alumni_ms': alumni_ms,
+        'alumni_undergrad': alumni_undergrad,
+        'alumni_highschool': alumni_highschool,
+        'cur_collaborators': cur_collaborators,
+        'past_collaborators': past_collaborators,
+        'positions': positions,
+        'banners': displayed_banners,
         'debug': settings.DEBUG
     }
     return render(request, 'website/people.html', context)
@@ -218,23 +221,24 @@ def member(request, member_id):
     # except Person.DoesNotExist:
     #     raise Http404("Person does not exist")
     # return render(request, 'website/member.html', {'person': person})
-    news_items_num = 5 # Defines the number of news items that will be selected
+    news_items_num = 5  # Defines the number of news items that will be selected
     all_banners = Banner.objects.filter(page=Banner.PEOPLE)
     displayed_banners = choose_banners(all_banners)
     # if (member_id.isdigit()):
     person = get_object_or_404(Person, pk=member_id)
     # else:
-        # person = get_object_or_404(Person, url_name__iexact=member_id)
+    # person = get_object_or_404(Person, url_name__iexact=member_id)
     news = person.news_set.order_by('-date')[:news_items_num]
     publications = person.publication_set.order_by('-date')
     talks = person.talk_set.order_by('-date')
-    context = { 'person': person,
-                'news': news,
-                'talks': talks,
-                'publications': publications,
-                'banners': displayed_banners,
-                'debug': settings.DEBUG }
+    context = {'person': person,
+               'news': news,
+               'talks': talks,
+               'publications': publications,
+               'banners': displayed_banners,
+               'debug': settings.DEBUG}
     return render(request, 'website/member.html', context)
+
 
 def publications(request):
     all_banners = Banner.objects.filter(page=Banner.PUBLICATIONS)
@@ -246,50 +250,55 @@ def publications(request):
     # See https://stackoverflow.com/a/4668703
     # sampledate__gte=datetime.date(2011, 1, 1),
     # Old: Publication.objects.filter(date__range=["2012-01-01", date.today()]),
-    context = { 'publications': Publication.objects.filter(date__gte=filter_all_pubs_prior_to_date),
-                'banners': displayed_banners,
-                'filter': filter,
-                'groupby': groupby,
-                'debug': settings.DEBUG }
+    context = {'publications': Publication.objects.filter(date__gte=filter_all_pubs_prior_to_date),
+               'banners': displayed_banners,
+               'filter': filter,
+               'groupby': groupby,
+               'debug': settings.DEBUG}
     return render(request, 'website/publications.html', context)
+
 
 def talks(request):
     all_banners = Banner.objects.filter(page=Banner.TALKS)
     displayed_banners = choose_banners(all_banners)
     filter = request.GET.get('filter', None)
     groupby = request.GET.get('groupby', "No-Group")
-    context = { 'talks': Talk.objects.filter(date__gte=filter_all_pubs_prior_to_date),
-                'banners': displayed_banners,
-                'filter': filter,
-                'groupby': groupby,
-                'debug': settings.DEBUG }
+    context = {'talks': Talk.objects.filter(date__gte=filter_all_pubs_prior_to_date),
+               'banners': displayed_banners,
+               'filter': filter,
+               'groupby': groupby,
+               'debug': settings.DEBUG}
     return render(request, 'website/talks.html', context)
+
 
 def videos(request):
     all_banners = Banner.objects.filter(page=Banner.TALKS)
     displayed_banners = choose_banners(all_banners)
     filter = request.GET.get('filter', None)
     groupby = request.GET.get('groupby', "No-Group")
-    context = { 'videos': Video.objects.filter(date__range=["2012-01-01", date.today()]), 'banners': displayed_banners, 'filter': filter, 'groupby': groupby, 'debug': settings.DEBUG }
+    context = {'videos': Video.objects.filter(date__range=["2012-01-01", date.today()]), 'banners': displayed_banners,
+               'filter': filter, 'groupby': groupby, 'debug': settings.DEBUG}
     return render(request, 'website/videos.html', context)
 
+
 def website_analytics(request):
-   return render(request, 'admin/analytics.html')
+    return render(request, 'admin/analytics.html')
+
 
 def projects(request):
-   all_banners = Banner.objects.filter(page=Banner.PROJECTS)
-   displayed_banners = choose_banners(all_banners)
-   projects = Project.objects.all()
-   all_proj_len = len(projects)
-   filter = request.GET.get('filter')
-   if filter != None:
-      filter_umbrella = Project_umbrella.objects.get(short_name=filter)
-      projects = filter_umbrella.project_set.all()
-   umbrellas = Project_umbrella.objects.all()
-   popular_projects = [] # sort_popular_projects(googleanalytics.run(get_ind_pageviews))[:4]
-   recent_projects = get_most_recent(Project.objects.order_by('-updated'))[:2]
+    all_banners = Banner.objects.filter(page=Banner.PROJECTS)
+    displayed_banners = choose_banners(all_banners)
+    projects = Project.objects.all()
+    all_proj_len = len(projects)
+    filter = request.GET.get('filter')
+    if filter != None:
+        filter_umbrella = Project_umbrella.objects.get(short_name=filter)
+        projects = filter_umbrella.project_set.all()
+    umbrellas = Project_umbrella.objects.all()
+    popular_projects = []  # sort_popular_projects(googleanalytics.run(get_ind_pageviews))[:4]
+    recent_projects = get_most_recent(Project.objects.order_by('-updated'))[:2]
 
-   context = { 'projects': projects,
+    context = {'projects': projects,
                'all_proj_len': all_proj_len,
                'banners': displayed_banners,
                'recent': recent_projects,
@@ -297,41 +306,43 @@ def projects(request):
                'umbrellas': umbrellas,
                'filter': filter,
                'debug': settings.DEBUG}
-   return render(request, 'website/projects.html', context)
+    return render(request, 'website/projects.html', context)
+
 
 # This is the view for individual projects, rather than the overall projects page
 def project(request, project_name):
-   project = get_object_or_404(Project, short_name__iexact=project_name)
-   all_banners = project.banner_set.all()
-   displayed_banners = choose_banners(all_banners)
-   project_members = project.project_role_set.order_by('start_date')
-   current_members = [] # = project_members.filter(is_active=True) # can't use is_active in filter because it's a function
-   alumni_members = [] # = project_members.filter(is_active=False).order_by('end_date')
+    project = get_object_or_404(Project, short_name__iexact=project_name)
+    all_banners = project.banner_set.all()
+    displayed_banners = choose_banners(all_banners)
+    project_members = project.project_role_set.order_by('start_date')
+    current_members = []  # = project_members.filter(is_active=True) # can't use is_active in filter because it's a function
+    alumni_members = []  # = project_members.filter(is_active=False).order_by('end_date')
 
-   for member in project_members:
-       if member.is_active():
-           current_members.append(member)
-       else:
-           alumni_members.append(member)
+    for member in project_members:
+        if member.is_active():
+            current_members.append(member)
+        else:
+            if member.is_past():
+                alumni_members.append(member)
 
-   #TODO: sort current members by PI, Co-PI first, then start date (oldest start date first), then role (e.g., professors, then grad, then undergrad),
-   #TODO: sorty alumni members by PI, CO-PI first, then date date (most recent end date first), then role
-   alumni_members = sorted(alumni_members, key=attrgetter('end_date'), reverse=True)
+    # TODO: sort current members by PI, Co-PI first, then start date (oldest start date first), then role (e.g., professors, then grad, then undergrad),
+    # TODO: sorty alumni members by PI, CO-PI first, then date date (most recent end date first), then role
+    alumni_members = sorted(alumni_members, key=attrgetter('end_date'), reverse=True)
 
-   publications = project.publication_set.order_by('-date')
-   videos = project.video_set.order_by('-date')
-   talks = project.talk_set.order_by('-date')
-   news = project.news_set.order_by('-date')
-   photos = project.photo_set.all()
-   project_members_dict = {
-       'Current Project Members' : current_members,
-       'Past Project Members' : alumni_members
-   }
+    publications = project.publication_set.order_by('-date')
+    videos = project.video_set.order_by('-date')
+    talks = project.talk_set.order_by('-date')
+    news = project.news_set.order_by('-date')
+    photos = project.photo_set.all()
+    project_members_dict = {
+        'Current Project Members': current_members,
+        'Past Project Members': alumni_members
+    }
 
-   context = { 'banners': displayed_banners,
+    context = {'banners': displayed_banners,
                'project': project,
-               'project_members' : project_members,
-               'project_members_dict' : project_members_dict,
+               'project_members': project_members,
+               'project_members_dict': project_members_dict,
                'publications': publications,
                'talks': talks,
                'videos': videos,
@@ -339,108 +350,118 @@ def project(request, project_name):
                'photos': photos,
                'debug': settings.DEBUG}
 
-   return render(request, 'website/project.html', context)
+    return render(request, 'website/project.html', context)
 
 
 def news(request, news_id):
-   all_banners = Banner.objects.filter(page=Banner.FRONTPAGE)
-   displayed_banners = choose_banners(all_banners)
-   news = get_object_or_404(News, pk=news_id)
-   max_extra_items = 4 # Maximum number of authors 
-   all_author_news = news.author.news_set.order_by('-date')
-   author_news = []
-   for item in all_author_news:
-      if item != news:
-         author_news.append(item)
-   project_news = {}
-   if news.project != None:
-      for project in news.project.all():
-         ind_proj_news = []
-         all_proj_news = project.news_set.order_by('-date')
-         for item in all_proj_news:
-            if item != news:
-               ind_proj_news.append(item)
-         project_news[project] = ind_proj_news[:max_extra_items]
+    all_banners = Banner.objects.filter(page=Banner.FRONTPAGE)
+    displayed_banners = choose_banners(all_banners)
+    news = get_object_or_404(News, pk=news_id)
+    max_extra_items = 4  # Maximum number of authors
+    all_author_news = news.author.news_set.order_by('-date')
+    author_news = []
+    for item in all_author_news:
+        if item != news:
+            author_news.append(item)
+    project_news = {}
+    if news.project != None:
+        for project in news.project.all():
+            ind_proj_news = []
+            all_proj_news = project.news_set.order_by('-date')
+            for item in all_proj_news:
+                if item != news:
+                    ind_proj_news.append(item)
+            project_news[project] = ind_proj_news[:max_extra_items]
 
-   context = { 'banners': displayed_banners,
+    context = {'banners': displayed_banners,
                'news': news,
                'author_news': author_news[:max_extra_items],
                'project_news': project_news,
-               'debug': settings.DEBUG }
-   return render(request, 'website/news.html', context)
+               'debug': settings.DEBUG}
+    return render(request, 'website/news.html', context)
+
 
 ## Helper functions for views ##
-
 def get_most_recent(projects):
-   updated = []
-   print(projects)
-   for project in projects:
-      #Adding more times to the time array will allow you to add additional fields in the future
-      times = []
-      if project.updated != None:
-         times.append(project.updated)
-      if len(project.publication_set.all()) > 0:
-         times.append(project.publication_set.order_by('-date')[0].date)
-      if len(project.talk_set.all()) > 0:
-         times.append(project.talk_set.order_by('-date')[0].date)
-      if len(project.video_set.all()) > 0:
-         times.append(project.video_set.order_by('-date')[0].date)
-      times.sort()
-      updated.append({'proj': project, 'updated': times[0]})
+    updated = []
+    print(projects)
+    for project in projects:
+        # Adding more times to the time array will allow you to add additional fields in the future
+        times = []
+        if project.updated != None:
+            times.append(project.updated)
+        if len(project.publication_set.all()) > 0:
+            times.append(project.publication_set.order_by('-date')[0].date)
+        if len(project.talk_set.all()) > 0:
+            times.append(project.talk_set.order_by('-date')[0].date)
+        if len(project.video_set.all()) > 0:
+            times.append(project.video_set.order_by('-date')[0].date)
+        times.sort()
+        updated.append({'proj': project, 'updated': times[0]})
 
-   sorted_list = sorted(updated, key=lambda k: k['updated'], reverse=True)
+    sorted_list = sorted(updated, key=lambda k: k['updated'], reverse=True)
 
-   # DEBUG
-   for item in sorted_list:
-       mostRecentArtifact = item['proj'].get_most_recent_artifact();
-       if mostRecentArtifact is not None:
-           print("project '{}' has the most recent artifact of {} updated {} and the check {}".format(item['proj'].name, mostRecentArtifact, mostRecentArtifact.date, item['updated']))
-       else:
-           print("mostRecentArtifact is none")
-   # END DEBUG
+    # DEBUG
+    for item in sorted_list:
+        mostRecentArtifact = item['proj'].get_most_recent_artifact();
+        if mostRecentArtifact is not None:
+            print(
+                "project '{}' has the most recent artifact of {} updated {} and the check {}".format(item['proj'].name,
+                                                                                                     mostRecentArtifact,
+                                                                                                     mostRecentArtifact.date,
+                                                                                                     item['updated']))
+        else:
+            print("mostRecentArtifact is none")
+    # END DEBUG
 
-   return [item['proj'] for item in sorted_list]
+    return [item['proj'] for item in sorted_list]
 
-#Get the page views per page including their first and second level paths
+
+# Get the page views per page including their first and second level paths
 def get_ind_pageviews(service, profile_id):
-  return service.data().ga().get(
-    ids='ga:' + profile_id,
-    start_date='30daysAgo',
-    end_date='today',
-    metrics='ga:pageviews',
-    dimensions='ga:PagePathLevel1,ga:PagePathLevel2'
-  ).execute().get('rows')
+    return service.data().ga().get(
+        ids='ga:' + profile_id,
+        start_date='30daysAgo',
+        end_date='today',
+        metrics='ga:pageviews',
+        dimensions='ga:PagePathLevel1,ga:PagePathLevel2'
+    ).execute().get('rows')
+
 
 def get_project(page):
-   proj = None
-   for project in Project.objects.all():
-      if project.short_name in page.lower():
-         proj = project
-   return proj
+    proj = None
+    for project in Project.objects.all():
+        if project.short_name in page.lower():
+            proj = project
+    return proj
+
 
 def sort_popular_projects(projects):
-   page_views = {}
-   for path, subpage, count in projects:
-      if 'project' in path:
-         proj=get_project(subpage)
-         if proj != None:
-            if proj in page_views.keys():
-               page_views[proj]+=int(count)
-            else:
-               page_views[proj]=int(count)
-   project_popularity=sorted([{'proj': key, 'views': page_views[key]} for key in page_views.keys()], key=lambda k: k['views'], reverse=True)
-   return [item['proj'] for item in project_popularity]
+    page_views = {}
+    for path, subpage, count in projects:
+        if 'project' in path:
+            proj = get_project(subpage)
+            if proj != None:
+                if proj in page_views.keys():
+                    page_views[proj] += int(count)
+                else:
+                    page_views[proj] = int(count)
+    project_popularity = sorted([{'proj': key, 'views': page_views[key]} for key in page_views.keys()],
+                                key=lambda k: k['views'], reverse=True)
+    return [item['proj'] for item in project_popularity]
+
 
 def weighted_choice(choices):
-   total = sum(w for c, w in choices)
-   r = random.uniform(0, total)
-   upto = 0
-   for c, w in choices:
-      if upto + w >= r:
-         return c
-      upto += w
-   # assert False, "Shouldn't get here"
-   return choices[0][0]
+    total = sum(w for c, w in choices)
+    r = random.uniform(0, total)
+    upto = 0
+    for c, w in choices:
+        if upto + w >= r:
+            return c
+        upto += w
+    # assert False, "Shouldn't get here"
+    return choices[0][0]
+
 
 def choose_banners_helper(banners, count):
     banner_weights = []
@@ -472,19 +493,20 @@ def choose_banners_helper(banners, count):
 
     return selected_banners
 
+
 def choose_banners(banners):
-  favorite_banners = []
-  other_banners = []
-  for banner in banners:
-    if banner.favorite == True:
-      favorite_banners.append(banner)
-    else:
-      other_banners.append(banner)
+    favorite_banners = []
+    other_banners = []
+    for banner in banners:
+        if banner.favorite == True:
+            favorite_banners.append(banner)
+        else:
+            other_banners.append(banner)
 
-  selected_banners = choose_banners_helper(favorite_banners, max_banners)
-  if len(selected_banners) < max_banners:
-    temp = choose_banners_helper(other_banners, max_banners - len(selected_banners))
-    for banner in temp:
-      selected_banners.append(banner)
+    selected_banners = choose_banners_helper(favorite_banners, max_banners)
+    if len(selected_banners) < max_banners:
+        temp = choose_banners_helper(other_banners, max_banners - len(selected_banners))
+        for banner in temp:
+            selected_banners.append(banner)
 
-  return selected_banners
+    return selected_banners


### PR DESCRIPTION
Fixes #260, #262, #363 (?)
* Future project members no longer show up on the Projects page and future collaborators no longer show up on the person page. (The collaborators problem wasn't officially documented as an issue, but it was a related problem that I noticed while I was testing). 
* I didn't see any functions that differentiated between past/future collaborators. I added in an `is_past` to Project Roles (in Models) and `is_past_collaborator` to Position (in Models)