### PR TITLE
Resolves #426: Update gitignore to exclude media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ ssl_access_log
 makeabilitylab_django.log
 
 static/
+
+media/


### PR DESCRIPTION
Fixes #426 
This should take care of `debug.log` files too (since these are also stored in media).