### PR TITLE
Citation Popover Issue

### DIFF
--- a/website/static/website/css/publications.css
+++ b/website/static/website/css/publications.css
@@ -1,5 +1,11 @@
 /* TODO: Cleanup the CSS in this file and start using artifact-title, artifact-venue, etc. from base.css */
 /* TODO: update--cleanup in progress. Note that any change here may impact publications.js and filterBar.js */
+@media only screen and (max-width: 600px){
+	.citation-link{
+		display: none;
+	}
+}
+
 
 @media (max-width: 768px){
     .publication-list {

--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -136,7 +136,7 @@
 	}
 
 	$.fn.updateCitationPopover = function() {
-		$(this).popover()
+		$(this).popover({placement: "auto right"})
 
 		// Manual trigger to get around idiosyncrasies of bootstrap's popover control
 		$(this).click(function() {

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -256,7 +256,7 @@
                         <p class="pub-download-links">
                             <a href="../../media/{{ pub.pdf_file }}">PDF</a>
                             {% if pub.official_url %}<a href="{{ pub.official_url }}">| Official Link</a> |{% endif %}
-                            | <a data-toggle="popover" data-html="true" data-trigger="manual" tabindex="0" title="Citation" data-content="Empty Citation" class="publication-citation-link">Citation</a>
+                            <span class="citation-link">| <a data-toggle="popover" data-html="true" data-trigger="manual" tabindex="0" title="Citation" data-content="Empty Citation" class="publication-citation-link">Citation</a></span>
                             {% if pub.talk.pdf_file %}<a href="../../media/{{ pub.talk.pdf_file }}">| Talk</a>{% endif %}
                         </p>
                     {% endif %}

--- a/website/templates/website/publications.html
+++ b/website/templates/website/publications.html
@@ -183,7 +183,7 @@
                     <span class="publication-keyword"><span class="publication-keyword-text">keyword</span>,&nbsp;</span>
                     <span class="publication-keyword-last"><span class="publication-keyword-text">keyword</span></span>
                     </p>
-                    <div class="publication-download">Download: <a href="link" class="publication-download-link">[pdf]</a> <span class="publication-video-link-label">| Video: <a href="link" class="publication-video-link">[youtube]</a></span> | Export <a data-toggle="popover" data-html="true" data-trigger="manual" tabindex="0" title="Citation" data-content="Empty Citation" class="publication-citation-link">[Citation]</a></div>
+                    <div class="publication-download">Download: <a href="link" class="publication-download-link">[pdf]</a> <span class="publication-video-link-label">| Video: <a href="link" class="publication-video-link">[youtube]</a></span> <span class="citation-link">| Export <a data-toggle="popover" data-html="true" data-trigger="manual" tabindex="0" title="Citation" data-content="Empty Citation" class="publication-citation-link">[Citation]</a></span></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
New PR based on master. Resolves #345: 
citations on a screen wider than 600 px will default to the right, but display left if it becomes cut-off
citations will not display on mobile