### PR TITLE
Fixes #381: Update url references

### DIFF
--- a/website/management/commands/updateurls.py
+++ b/website/management/commands/updateurls.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         print('Updating urls...')
         for person in Person.objects.all():
-            print('Name: ' + person.first_name + person.last_name)
-            person.url_name = (person.first_name + person.last_name).lower()
+            print('Name: ' + person.first_name + ' ' + person.last_name)
+            person.url_name = (person.first_name + person.last_name).lower().replace(' ', '')
             print('URL Name: ' + person.url_name)
             person.save()

--- a/website/models.py
+++ b/website/models.py
@@ -215,7 +215,7 @@ class Person(models.Model):
         image_choice = File(open(star_wars_dir+get_random_starwars(star_wars_dir), 'rb'))
 
         # automatically set url_name field
-        self.url_name = (self.first_name + self.last_name).lower()
+        self.url_name = (self.first_name + self.last_name).lower().replace(' ', '')
         if not self.image:
             self.image = image_choice
         if self.pk is None:

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -66,7 +66,7 @@
                 "first_name": "{{ author.first_name }}",
                 "middle_name": "{{ author.middle_name }}",
                 "last_name": "{{ author.last_name }}",
-                "link": "{% url 'website:member' author.id %}"
+                "link": "{% url 'website:member' author.url_name %}"
                 },
             {% endfor %}
             ],
@@ -243,7 +243,7 @@
                     </p>
                     <p class="artifact-authors line-clamp3">
                         {% for author in pub.authors.all %}
-                            <a href="{% url 'website:member' author.id %}">{{author.get_full_name}}</a>{% if not forloop.last %},{% endif %}
+                            <a href="{% url 'website:member' author.url_name %}">{{author.get_full_name}}</a>{% if not forloop.last %},{% endif %}
                         {% endfor %}
                     </p>
 
@@ -290,7 +290,7 @@
                             <!-- TODO: figure out how to remove vertical space between speakers and subtitle -->
 
                             {% for speaker in talk.speakers.all %}
-                                <a href="{% url 'website:member' speaker.id %}">{{ speaker.get_full_name }}</a>{% if not forloop.last %}, {% endif %}
+                                <a href="{% url 'website:member' speaker.url_name %}">{{ speaker.get_full_name }}</a>{% if not forloop.last %}, {% endif %}
                             {% endfor %}
                         </p>
                         <!-- TODO: add in YouTube of talk? -->

--- a/website/templates/website/member.html
+++ b/website/templates/website/member.html
@@ -144,7 +144,7 @@
 					<p>{{item.title}}</p>
 				    </a>
 				</div>
-				<p class="news_date">{{item.short_date}} | <a href="{% url 'website:member' item.author.id %}">{{item.author.first_name}}</a></p><!--</p><p class="news_date">{{item.author}}</p>-->
+				<p class="news_date">{{item.short_date}} | <a href="{% url 'website:member' item.author.url_name %}">{{item.author.first_name}}</a></p><!--</p><p class="news_date">{{item.author}}</p>-->
 			    </div>
 			</div>
 			<div class="row news_body">
@@ -178,7 +178,7 @@
 				<p class="publication-title">{{pub.title}}</p>
 				<p class="publication-authors">
 				    {% for author in pub.authors.all %}
-				    <span class="publication-author"><a href="{% url 'website:member' author.id %}">{{author.get_full_name}}</a>&nbsp;</span>
+				    <span class="publication-author"><a href="{% url 'website:member' author.url_name %}">{{author.get_full_name}}</a>&nbsp;</span>
 				    {% endfor %}
 				</p>
 				<p class="publication-stats">


### PR DESCRIPTION
Hopefully resolves some of the issues that came up on production in #381 

This error kept coming up in the UW`debug.log` file: `django.core.urlresolvers.NoReverseMatch: Reverse for 'member' with arguments '('victorde souza',)' and keyword arguments '{}' not found. 2 pattern(s) tried: ['member/(?P<member_id>[-a-z]+)/$', 'member/(?P<member_id>[0-9]+)/$']`. It makes sense -- urls is not expecting a space in a person's url name!

I included an extra command to get rid of whitespaces. (Both in the `updateurls` command and the `save` command for person that fills the `url_name` column). Hopefully it works!

I also made some other miscellaneous fixes - I noticed that the landing page + one place in news was still referencing authors/speakers by ids instead of names. (This is done in the more recent commit)