### PR TITLE
Landing page fixes

### DIFF
--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -151,7 +151,7 @@
         <h1 class="section-header" style="margin-top:25px">Recent Projects</h1>
         <div class="section">
             {% for project in projects|slice:"8" %}
-                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 project-column">
+                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 project-column" style="margin-bottom:20px">
                         <a href="{% url 'website:project' project.short_name %}"></a>
                          <div style="background: black; width:100%; height: 180px; contain: content;">
                              <img style="width:100%; height: auto; position: relative;top: 50%; left: 50%;transform: translate(-50%,-50%);object-fit: cover" src="{% thumbnail project.gallery_image "300x180" crop="center" %}">

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -162,7 +162,10 @@
             <div class="row justify-content-end">
                 <!-- TODO fix the right alignment -->
                 <div class="col-xs-12 see-all-artifacts">
-                    <a href="{% url 'website:projects' %}">See All Projects ></a>
+                    <div class="col-xs-12"></div>
+                    <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 see-all-artifacts pull-right see-all-artifacts">
+                        <a href="{% url 'website:projects' %}">See All Projects ></a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -211,7 +214,10 @@
                 </div>
             {% endfor %}
             <div class="col-xs-12 see-all-artifacts">
-                <a href="{% url 'website:videos' %}">See All Videos ></a>
+                <div class="col-xs-12"></div>
+                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 see-all-artifacts pull-right see-all-artifacts">
+                    <a href="{% url 'website:videos' %}" style="margin:15px">See All Videos ></a>
+                </div>
             </div>
         </div>
     </div>
@@ -261,7 +267,10 @@
                 </div>
             {% endfor %}
             <div class="col-xs-12 see-all-artifacts">
-                <a href="{% url 'website:publications' %}">See All Papers ></a>
+                <div class="col-xs-12"></div>
+                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 see-all-artifacts pull-right see-all-artifacts">
+                    <a href="{% url 'website:publications' %}" style="margin:15px">See All Papers ></a>
+                </div>
             </div>
         </div>
     </div>
@@ -299,7 +308,10 @@
                 </div>
             {% endfor %}
             <div class="col-xs-12 see-all-artifacts">
-                <a href="{% url 'website:talks' %}">See All Talks ></a>
+                <div class="col-xs-12"></div>
+                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 see-all-artifacts pull-right see-all-artifacts">
+                    <a href="{% url 'website:talks' %}" style="margin:15px">See All Talks ></a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/21998904/43055917-137a5a70-8dee-11e8-972f-d7e361e72c8a.png)
after:
![image](https://user-images.githubusercontent.com/21998904/43056054-c85d53fc-8dee-11e8-9284-25c511ed16df.png)
fixes the alignment bug for the "see all", adds in spacing between projects