### PR TITLE
fixes #466

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -438,10 +438,10 @@
                     {% for news_item in recent_news %}
                         <div class="row">
                             <a href="{% url 'website:news' news_item.id %}">
-                                <div class="col-xs-5">
+                                <div class="col-xs-4" style="white-space:nowrap;">
                                     <p>{{ news_item.date|date:"N d, Y" }}</p>
                                 </div>
-                                <div class="col-xs-7">
+                                <div class="col-xs-8">
                                     <p class= "line-clamp">{{ news_item.title }}</p>
                                 </div>
                             </a>

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -439,6 +439,7 @@
                         <div class="row">
                             <a href="{% url 'website:news' news_item.id %}">
                                 <div class="col-xs-4" style="white-space:nowrap;">
+				    {#  Date formats here: https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#std:templatefilter-date #}	
                                     <p>{{ news_item.date|date:"N d, Y" }}</p>
                                 </div>
                                 <div class="col-xs-8">

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -435,12 +435,18 @@
                     {# To add news dynamically, we need to use a context processor. See our custom process in context_processors.py #}
                     {# See: https://stackoverflow.com/questions/36093221/how-to-put-variable-from-database-into-base-html-template #}
 
-                    <ul>
                     {% for news_item in recent_news %}
-                        {#  Date formats here: https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#std:templatefilter-date #}
-                        <li><a href="{% url 'website:news' news_item.id %}">{{ news_item.date|date:"N d, Y" }} &nbsp;&nbsp;&nbsp; {{ news_item.title }}</a></li>
+                        <div class="row">
+                            <a href="{% url 'website:news' news_item.id %}">
+                                <div class="col-xs-5">
+                                    <p>{{ news_item.date|date:"N d, Y" }}</p>
+                                </div>
+                                <div class="col-xs-7">
+                                    <p class= "line-clamp">{{ news_item.title }}</p>
+                                </div>
+                            </a>
+                        </div>
                     {% endfor %}
-                    </ul>
 
                 </div>
 


### PR DESCRIPTION
old:
![image](https://user-images.githubusercontent.com/21998904/43093710-a7c645b4-8e65-11e8-9333-36f5cefdd167.png)

new:
![image](https://user-images.githubusercontent.com/21998904/43093642-72803536-8e65-11e8-8199-eba056a27d4d.png)

Done using bootstrap collumns, replaced &nsbp. Also added line-clamping for long titles.
