### PR TITLE
Resolves #475: adds conditional check to see if video has a publication pdf

### DIFF
--- a/website/templates/website/videos.html
+++ b/website/templates/website/videos.html
@@ -35,7 +35,9 @@
             "url_embeddable": "{{video.get_embed}}",
             "project_short_name": "{{video.project.short_name}}",
             "pub_title": "{{video.publication}}",
-            "pub_url": "../../media/{{video.publication.pdf_file}}"
+            {% if video.publication.pdf_file %}
+                "pub_url": "../../media/{{video.publication.pdf_file}}"
+            {% endif %}
         },
 		{% endfor %}
 	];


### PR DESCRIPTION
Fixes #475.

Added a conditional check in `videos.js` to make sure that there is a publication associated with a video to list a Paper. 

Example:
![image](https://user-images.githubusercontent.com/25534091/43114566-92ff0ff4-8eb4-11e8-8586-45a62f065780.png)

Previously, it showed a Paper link that directed to `/media`, which causes a 403 error.
