### PR TITLE
Cursor now changes to pointer for citations

### DIFF
--- a/website/static/website/css/publications.css
+++ b/website/static/website/css/publications.css
@@ -28,6 +28,7 @@
 .citation-links {
     text-align: right;
     margin-bottom: -5px;
+	cursor: pointer;
 }
 
 .publication-list h1 {

--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -21,7 +21,7 @@
 		    });
 		});
 
-		this.attr("data-content", createCitationText(pub));
+		$(this).attr("data-content", createCitationText(pub));
 
 		$(this).updateCitationPopover();
 
@@ -30,7 +30,7 @@
 
 	// combines and formats the citation metadata for display
 	function createCitationText(pub) {
-		var text = "<div class=\"citation-links\"><a id=\"citation-link\" onclick=\"$(this).citationclick()\">Citation</a> | <a id=\"bibtex-link\" onclick=\"$(this).bibtexclick()\">Bibtex</a></div><br/>";
+		var text = "<div class=\"citation-links\"><a id=\"citation-link\" onclick=\"$(this).citationclick()\">Citation</a> | <a id=\"bibtex-link\" onclick=\"$(this).bibtexclick()\" >Bibtex</a></div><br/>";
 	    // authors
 	    text+="<div id=\"citation-text\">";
 		pub.authors.forEach(function(author, index, array) {


### PR DESCRIPTION
Addresses old issue #421, added `cursor: pointer` to publication.css `citation-links`. This will cause any link tagged with citation-links to change the cursor to pointer on hover. 

Works both in on the landing page and the publications page.