### PR TITLE
Prepend Media to image file path.

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -231,7 +231,7 @@ class Person(models.Model):
     def save(self, *args, **kwargs):
         dir = os.path.abspath('.')
         # requires the volume mount from docker
-        dir = os.path.join('images', 'StarWarsFiguresFullSquare', 'Rebels')
+        dir = os.path.join('media', 'images', 'StarWarsFiguresFullSquare', 'Rebels')
         star_wars_dir = os.path.join(dir, get_random_starwars(dir))
         image_choice = File(open(star_wars_dir, 'rb'))
         # automatically set url_name field


### PR DESCRIPTION
One line fix to prepend media to the image path when retrieving an easter egg image. Helps ensure that the image path will point to the right directory, as somehow, volume mounts may not work in a Docker-Pycharm enviroment because the docker server is being ran differently.

Works in a none Docker-Pycharm environment, needs testing on a Docker-Pycharm dev environment.