### PR TITLE
Fixing landing page.  Fixes #301, fixes #448, fixes #505.

### DIFF
--- a/website/static/website/css/index.css
+++ b/website/static/website/css/index.css
@@ -49,6 +49,7 @@ research-area-icon-label{
     /*margin-left: 40px;*/
     /*margin-right: 40px;*/
     max-width: 1400px;
+    width: 100%;
     margin-left: auto;
     margin-right: auto;
 }

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -147,25 +147,23 @@
               https://stackoverflow.com/questions/15757036/creating-a-zoom-effect-on-an-image-on-hover-using-css
     -->
 
-    <div id="makelab-recent-projects" class="makelab-content-container">
+    <div id="makelab-recent-projects" class="container-fluid makelab-content-container">
         <h1 class="section-header" style="margin-top:25px">Recent Projects</h1>
         <div class="section">
             {% for project in projects|slice:"8" %}
                 <!-- Extra conditional added to not display projects with zero publications -->
                 {% if project.get_most_recent_publication %}
-                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 project-column" style="margin-bottom:20px">
+                    <div class="col-xs-6 col-md-4 col-lg-3 project-column" style="margin:15px; width: 300px; height: 200px">
+                        <img src="{% thumbnail project.gallery_image "300x180" crop="center" %}">
                         <a href="{% url 'website:project' project.short_name %}"></a>
-                         <div style="background: black; width:100%; height: 180px; contain: content;">
-                             <img style="width:100%; height: auto; position: relative;top: 50%; left: 50%;transform: translate(-50%,-50%);object-fit: cover" src="{% thumbnail project.gallery_image "300x180" crop="center" %}">
-                         </div>
                         <p class="artifact-title">{{ project.name }}</p>
-                </div>
+                    </div>
                 {% endif %}
             {% endfor %}
             <div class="row justify-content-end">
                 <!-- TODO fix the right alignment -->
                 <div class="col-xs-12 see-all-artifacts">
-                    <div class="col-xs-12"></div>
+                    <div class="col-xs-12" style="display:none"></div>
                     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 see-all-artifacts pull-right">
                         <a href="{% url 'website:projects' %}">See All Projects ></a>
                     </div>
@@ -194,7 +192,7 @@
 {#    </div>#}
 
     <!-- TODO: the ../../media directory should be a variable and not a constant -->
-    <div id="makelab-recent-videos" class="makelab-content-container">
+    <div id="makelab-recent-videos" class="container-fluid makelab-content-container">
         <h1 class="section-header">Recent Videos</h1>
         <div class="section">
             <!-- TODO: Consider adding age of video into display somehow -->
@@ -223,7 +221,7 @@
     </div>
 
 
-    <div id="makelab-recent-papers" class="makelab-content-container">
+    <div id="makelab-recent-papers" class="container-fluid makelab-content-container">
         <h1 class="section-header">Recent Papers</h1>
         <div class="section">
             {% for pub in publications|slice:"6" %}
@@ -273,21 +271,19 @@
     </div>
 
 
-    <div id="makelab-recent-talks" class="makelab-content-container">
+    <div id="makelab-recent-talks" class="container-fluid makelab-content-container">
         <h1 class="section-header">Recent Talks</h1>
         <div class="section">
 
             <!-- TODO: add in date of talk somewhere--or better yet, age? e.g., 4d, 4months ago -->
             {% for talk in talks|slice:"8" %} <!-- Switch slice to '4' to just display 4 talks -->
-                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+                <div class="col-xs-6 col-md-4 col-lg-3" style="margin:10px; width: 300px; height: 200px">
                     <div style="width: 100%; height: 300px; contain: content;">
                         <div class="talk2-thumbnail">
                             <!-- TODO: I don't get this thumbnail stuff; need to talk to Lee about it -->
-                                <a href="../../media/{{ talk.pdf_file }}">
-                                    <div style="background: black; width:100%; height: 180px; contain: content;">
-                                        <img style="width:100%; height: auto; position: relative;top: 50%; left: 50%;transform: translate(-50%,-50%);object-fit: cover" src="{% thumbnail talk.thumbnail 420x0 detail %}" class="talk2-thumbnail-image img-responsive">
-                                    </div>
-                                </a>
+                            <a href="../../media/{{ talk.pdf_file }}">
+                                <img src="{% thumbnail talk.thumbnail 420x0 detail %}" class="talk2-thumbnail-image img-responsive">
+                            </a>
                         </div>
                         <div class="talk-text">
                             <!-- TODO: href the talk title as well -->


### PR DESCRIPTION
fixes #301, fixes #448, fixes #505
fixes makelab footer, increases content max-width to 1400px successfully,fixes talks/projects sizing, and removes the black borders.
Now looks like this on large screens:
![image](https://user-images.githubusercontent.com/21998904/43552445-62193558-959f-11e8-912c-3188907b2839.png)

