### PR TITLE
Fix to NaN error on FireFox

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -75,18 +75,37 @@
         // $("#back-top").hide();
     });
 
+    function parseHashtoAnchor(string){
+        if(!isNaN(parseInt(string))){
+            return string.trim();
+        }
+        string = string.replace(/-/g, " ");
+        string = string.trim();
+        var stringArray = string.split(" ");
+        var returnVal = '';
+        stringArray.forEach(function(element){
+           element = element.charAt(0).toUpperCase() + element.substring(1, element.length);
+           returnVal = returnVal + element + " ";
+        });
+        return returnVal.trim()
+
+    }
+
     // allow for smooth scrolling to anchor links
     $(document).click(function (event) {
-	var clickedElement = event.originalEvent.srcElement;
-        if (clickedElement.className === "scroll" || clickedElement.parentElement.className === "scroll") {
+	var target = event.originalEvent.target;
+        if (target.className === "scroll" || target.parentElement.className === "scroll") {
             //prevent the default action for the click event
             event.preventDefault();
 
-            var element = clickedElement.className === "scroll" ? clickedElement : clickedElement.parentElement;
+            var element = target.className === "scroll" ? target : target.parentElement;
 
             //get the top offset of the target anchor
             var hashName = element.hash.substring(1);
+            hashName = parseHashtoAnchor(hashName);
+            console.log(hashName)
             var target_offset = $('[name=' + hashName + ']').offset();
+            console.log(target_offset)
             var target_top = target_offset.top - 60;
 
             //goto that anchor by setting the body scroll top to anchor top

--- a/website/templates/website/publications.html
+++ b/website/templates/website/publications.html
@@ -31,6 +31,7 @@
 {% endblock %}
 
 {% block scripts %}
+    {% load ml_tags %}
     var publications = [
         {% for pub in publications %}
         {
@@ -47,7 +48,7 @@
                 },
             {% endfor %}
             ],
-            "date": new Date("{{ pub.date }}"),
+            "date": {{ pub.date|jsdate }},
             "pdf": "../../media/{{ pub.pdf_file }}",
             "video_url": "{{ pub.video.video_url }}",
             "thumbnail": "{% thumbnail pub.thumbnail 300x0 detail %}",

--- a/website/templatetags/ml_tags.py
+++ b/website/templatetags/ml_tags.py
@@ -8,3 +8,12 @@ register = template.Library()
 @register.filter
 def get_item(dictionary, key):
     return dictionary.get(key)
+
+@register.filter(name='jsdate')
+def jsdate(d):
+    """formats a python date into a js Date() constructor.
+    """
+    try:
+        return "new Date({0},{1},{2})".format(d.year, d.month - 1, d.day)
+    except AttributeError:
+        return 'undefined'


### PR DESCRIPTION
This PR addresses the errors that occurs on FireFox with some dates displaying "NaN" in the filter, thus becoming unfilterable. 

The issue was that some date objects were not being generated correctly, leading to invalid date errors that were masked as TypeErrors. 

Before, the JSON date objects were being generated in the template.
Now, I have moved that to a template filter in `ml_tags.py`, which will preprocess the python date object into JSON date objects.

In addition, I have also included a fix to a scrolling bug that I discovered while dealing with this issue. That is, that other than when filtering by year, the filter bar will not scroll to the correct header. The reason behind this bug was the differences between the hashname and the name set in the template. For example, the hash name for conference was `conference` while in the template the name was `Conference`, note the capitalization. Therefore, it was necessary to include some kind of preprocessing mechanism to change the hash name to match the name set in the template.

# Makeability-Test
[![Image from Gyazo](https://i.gyazo.com/d9cacb1f5bfa77525189011e61472a13.gif)](https://gyazo.com/d9cacb1f5bfa77525189011e61472a13)
# New Branch
[![Image from Gyazo](https://i.gyazo.com/8b74c61b8a0276c377189a26f22189de.gif)](https://gyazo.com/8b74c61b8a0276c377189a26f22189de)

The scrolling only works on some projects and the years groups because some projects are all lowercase and numbers aren't affected by capitalization