### PR TITLE
Additional news fixes

### DIFF
--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -114,10 +114,10 @@
         {% for n in news %}
 	    <div class="news-listing-template">
                 <div class="news-listing-image">
-                    {% if news.image %}
-                    <img src="{% thumbnail n.image 200x200 box=news.cropping crop detail %}" class="news-listing-image-image img-responsive"/>
+                    {% if n.image %}
+                        <img src="{% thumbnail n.image 200x200 box=news.cropping crop detail %}" class="news-listing-image-image img-responsive"/>
                     {% else %}
-                    <img src="{% static 'website/img/news_icon.png' %}" class="big-news-image" height="200" width="200">
+                        <img src="{% static 'website/img/news_icon.png' %}" class="big-news-image" height="200" width="200">
                     {% endif %}
                 </div>
                 <div class="news-listing-info">
@@ -127,7 +127,7 @@
                             <span class="news-listing-author-last">{{ n.short_date }}</span>
                     </p>
                     <p class="news-listing-content">
-                        <span>{{ n.content | slice:":255" }} . . . <a href="{% url 'website:news' news_id=n.id %}">[read more]</a></span>
+                        <span>{{ n.content | slice:":255" | safe}} . . . <a href="{% url 'website:news' news_id=n.id %}">[read more]</a></span>
                     </p>
                 </div>
 

--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -120,14 +120,15 @@
                         <img src="{% static 'website/img/news_icon.png' %}" class="big-news-image" height="200" width="200">
                     {% endif %}
                 </div>
-                <div class="news-listing-info">
+                <div class="news-listing-info" style="margin-top: 10px;">
                     <p class="artifact-title" style="font-size:28px;">{{ n.title }}</p>
-                    <p class="news-listing-author-outside">
+                    <p class="news-listing-author-outside" style="margin-bottom: 10px;">
                         <span class="news-listing-author"><a href="{% url 'website:member' member_id=n.author.id %}">{{ n.author }}</a> &mdash;</span>
                             <span class="news-listing-author-last">{{ n.short_date }}</span>
                     </p>
                     <p class="news-listing-content">
-                        <span>{{ n.content | slice:":255" | safe}} . . . <a href="{% url 'website:news' news_id=n.id %}">[read more]</a></span>
+                        <span class="line-clamp">{{ n.content | safe}}</span>
+                        <a href="{% url 'website:news' news_id=n.id %}">[read more]</a>
                     </p>
                 </div>
 


### PR DESCRIPTION
Fixed all the issues listed in #467 

A typo led to all the images being displayed as the news icons, it has been corrected.
Using the `safe` template filter, html tags will now be rendered not as plain text but mark up instead.
Line clamps at 2 lines per item. 
