### PR TITLE
fixing news list and footer

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -459,8 +459,8 @@
                             </ul>
                         </div>
                 </div>
-                
-                <div class="col-xs-3 makelab-footer-col" style="margin-left: 0em; padding-right: 0em;">
+
+                <div class="col-xs-4 col-lg-3 makelab-footer-col" style="margin-left: 0em; padding-right: 0em;">
                     <h1>Recent News</h1>
                     {# To add news dynamically, we need to use a context processor. See our custom process in context_processors.py #}
                     {# See: https://stackoverflow.com/questions/36093221/how-to-put-variable-from-database-into-base-html-template #}
@@ -468,12 +468,12 @@
                     {% for news_item in recent_news %}
                         <div class="row">
                             <a href="{% url 'website:news' news_item.id %}">
-                                <div class="col-xs-4" style="white-space:nowrap;">
-				    {#  Date formats here: https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#std:templatefilter-date #}	
+                                <div class="col-xs-3" style="white-space:nowrap;min-width:115px">
+				    {#  Date formats here: https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#std:templatefilter-date #}
                                     <p>{{ news_item.date|date:"N d, Y" }}</p>
                                 </div>
-                                <div class="col-xs-8">
-                                    <p class= "line-clamp">{{ news_item.title }}</p>
+                                <div style="max-width: 300px; width:100%;">
+                                   <p class= "line-clamp">{{ news_item.title }}</p>
                                 </div>
                             </a>
                         </div>
@@ -486,23 +486,16 @@
                     <ul>
                         {% with request.resolver_match.url_name as url_name %}
 {#                            <li>url_name: {{ url_name  }}</li>#}
-                            <li class="{% if url_name == 'index' %}active{% endif %}"><a href="{% url 'website:index' %}"> &nbsp;> &nbsp; Home</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'index' %}active{% endif %}"><a href="{% url 'website:index' %}"> &nbsp;> &nbsp; Home</a></li>
     {#                        <li>About Us</li>#}
-                            <li class="{% if url_name == 'people' %}active{% endif %}"><a href="{% url 'website:people' %}">&nbsp;> &nbsp; People</a></li>
-                            <li class="{% if url_name == 'news_listing' %}active{% endif %}"><a href="{% url 'website:news_listing' %}">&nbsp;> &nbsp; News</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'people' %}active{% endif %}"><a href="{% url 'website:people' %}">&nbsp;> &nbsp; People</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'news_listing' %}active{% endif %}"><a href="{% url 'website:news_listing' %}">&nbsp;> &nbsp; News</a></li>
     {#                  <li class="{% if url_name == 'projects' %}active{% endif %}"><a href="{% url 'website:projects' %}">&nbsp;> &nbsp; Projects</a></li>#}
-                            <li class="{% if url_name == 'publications' %}active{% endif %}"><a href="{% url 'website:publications' %}">&nbsp;> &nbsp; Publications</a></li>
-                            <li class="{% if url_name == 'talks' %}active{% endif %}"><a href="{% url 'website:talks' %}">&nbsp;> &nbsp; Talks</a></li>
-                            <li class="{% if url_name == 'videos' %}active{% endif %}"><a href="{% url 'website:videos' %}">&nbsp;> &nbsp; Videos</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'publications' %}active{% endif %}"><a href="{% url 'website:publications' %}">&nbsp;> &nbsp; Publications</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'talks' %}active{% endif %}"><a href="{% url 'website:talks' %}">&nbsp;> &nbsp; Talks</a></li>
+                            <li style="white-space:nowrap;" class="{% if url_name == 'videos' %}active{% endif %}"><a href="{% url 'website:videos' %}">&nbsp;> &nbsp; Videos</a></li>
                         {% endwith %}
                     </ul>
-                </div>
-                
-                
-
-                
-                <div class="col-xs-3 makelab-footer-col">
-
                 </div>
             </div>
 

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -120,17 +120,18 @@
     {# Call the parent block #}
     {{ block.super }}
 
-
-    <!-- This is a news overlay on the banner -->
-    <div class="container-fluid news-listing" style="z-index: 15; position: absolute; top: 100px; right: 150px; background: rgba(0, 0, 0, 0.65); padding: 6px 10px 1px 10px; border-radius: 5px">
-        <div style="width: 200px">
-            {% for news_item in news|slice:"5" %}
-                <p class="line-clamp" style="margin-bottom:15px; color:white; font-family:Roboto;">
-                    <a href="{% url 'website:news' news_item.id %}">
-                        <span style="color:rgb(245,245,245);"><span style="font-family: roboto-bold; font-weight: 700;">{{ news_item.date }}.</span> {{ news_item.title }}</span>
-                    </a>
-                </p>
-            {% endfor %}
+    <div class="container-fluid makelab-content-container" style="z-index: 15;right:0;left:0;position: absolute;top:0px">
+         <!-- This is a news overlay on the banner -->
+        <div class="container-fluid news-listing pull-right" style="z-index: 15; position: relative; top: 100px; background: rgba(0, 0, 0, 0.65); padding: 6px 10px 1px 10px; border-radius: 5px; p">
+            <div style="width: 200px">
+                {% for news_item in news|slice:"5" %}
+                    <p class="line-clamp" style="margin-bottom:15px; color:white; font-family:Roboto;">
+                        <a href="{% url 'website:news' news_item.id %}">
+                            <span style="color:rgb(245,245,245);"><span style="font-family: roboto-bold; font-weight: 700;">{{ news_item.date }}.</span> {{ news_item.title }}</span>
+                        </a>
+                    </p>
+                {% endfor %}
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
fixes #500, fixes #532.

news list now aligned to the content:
![image](https://user-images.githubusercontent.com/21998904/43659308-7911f502-9710-11e8-8444-1bc2b50ca361.png)
news footer now has fixed spacing for each row:
![image](https://user-images.githubusercontent.com/21998904/43659200-1d4da798-9710-11e8-8425-1932157e451b.png)
date no longer wraps:
![image](https://user-images.githubusercontent.com/21998904/43659252-4cf9420e-9710-11e8-97ac-ed614fd753bd.png)
