### PR TITLE
one line fix to issue #521

### DIFF
--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -117,7 +117,7 @@
                     {% if n.image %}
                         <img src="{% thumbnail n.image 200x200 box=news.cropping crop detail %}" class="news-listing-image-image img-responsive"/>
                     {% else %}
-                        <img src="{% static 'website/img/news_icon.png' %}" class="big-news-image" height="200" width="200">
+                        <img src="{% static 'website/img/news_icon.png' %}" class="big-news-image" height="110" width="110">
                     {% endif %}
                 </div>
                 <div class="news-listing-info" style="margin-top: 10px;">


### PR DESCRIPTION
Fixes the different sized images by adjusting the default news image to the size of the cropped images. 