### PR TITLE
Quick additional REST API feature

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -33,7 +33,7 @@ class TalkList(APIView):
     '''
     def get(self, request, format = None):
         talks = Talk.objects.all()
-        serializer = TalkSerializer(talks,many=True)
+        serializer = TalkSerializer(talks,many=True,context={'request': request})
         return Response(serializer.data)
 
     def post(self, request, format=None):
@@ -77,7 +77,7 @@ class PubsList(APIView):
     '''
     def get(self, request, format = None):
         pubs = Publication.objects.all()
-        serializer = PublicationSerializer(pubs,many=True)
+        serializer = PublicationSerializer(pubs,many=True, context={'request': request})
         return Response(serializer.data)
 
     def post(self, request, format=None):


### PR DESCRIPTION
Serializes the absolute path of the file on the server instead of a relative path beginning at media (Example: `/media/publications/Evaluating_Angular_Accuracy_of_Wristbased_Haptic_Directional_Guidance_for_Hand_Movement_nIxCCJA.pdf` will become `https://makeabilitylab.cs.washington.edu/media/publications/Evaluating_Angular_Accuracy_of_Wrist-based_Haptic_Directional_Guidance_for_Hand_Movement_nIxCCJA.pdf`)