### PR TITLE
Updated Filter to Recent Projects

### DIFF
--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -152,8 +152,6 @@
         <h1 class="section-header" style="margin-top:25px">Recent Projects</h1>
         <div class="section">
             {% for project in projects|slice:"8" %}
-                <!-- Extra conditional added to not display projects with zero publications -->
-                {% if project.get_most_recent_publication %}
                     <div class="col-ts-12 col-xs-6 col-sm-4 col-lg-3" style="margin-bottom:20px">
                         <a href="{% url 'website:project' project.short_name %}">
                             <div style="background: white; width:100%; height: 180px; contain: content;">
@@ -162,7 +160,6 @@
                         </a>
                         <p class="artifact-title">{{ project.name }}</p>
                     </div>
-                {% endif %}
             {% endfor %}
             <div class="row justify-content-end">
                 <!-- TODO fix the right alignment -->

--- a/website/views.py
+++ b/website/views.py
@@ -47,7 +47,7 @@ def index(request):
     # sorted(projects, key=lambda project: student[2])
     projects = Project.objects.all()
     projects = get_most_recent(projects);
-    projects = filter_projects(projects);
+    projects = filter_no_pubs_projects(projects);
 
     context = {'people': Person.objects.all(),
                'banners': displayed_banners,
@@ -393,7 +393,7 @@ def get_most_recent(projects):
 
     return [item['proj'] for item in sorted_list]
 
-def filter_projects(projects):
+def filter_no_pubs_projects(projects):
     filtered = []
     for project in projects:
         if len(project.publication_set.all()) > 0:
@@ -492,4 +492,4 @@ def choose_banners(banners):
         for banner in temp:
             selected_banners.append(banner)
 
-    return selected_banners    
+    return selected_banners

--- a/website/views.py
+++ b/website/views.py
@@ -400,8 +400,6 @@ def filter_projects(projects):
             filtered.append(project)
     return filtered
 
-
-
 # Get the page views per page including their first and second level paths
 def get_ind_pageviews(service, profile_id):
     return service.data().ga().get(

--- a/website/views.py
+++ b/website/views.py
@@ -47,6 +47,7 @@ def index(request):
     # sorted(projects, key=lambda project: student[2])
     projects = Project.objects.all()
     projects = get_most_recent(projects);
+    projects = filter_projects(projects);
 
     context = {'people': Person.objects.all(),
                'banners': displayed_banners,
@@ -392,6 +393,14 @@ def get_most_recent(projects):
 
     return [item['proj'] for item in sorted_list]
 
+def filter_projects(projects):
+    filtered = []
+    for project in projects:
+        if len(project.publication_set.all()) > 0:
+            filtered.append(project)
+    return filtered
+
+
 
 # Get the page views per page including their first and second level paths
 def get_ind_pageviews(service, profile_id):
@@ -485,4 +494,4 @@ def choose_banners(banners):
         for banner in temp:
             selected_banners.append(banner)
 
-    return selected_banners
+    return selected_banners    


### PR DESCRIPTION
Put in an extra function to filter the projects first before displaying them on recent projects that way even when slicing in different amounts, which in this case is 8, that number will at least show up considering there are that many projects.
<img width="1440" alt="screen shot 2018-08-07 at 12 36 04 pm" src="https://user-images.githubusercontent.com/32470028/43798292-fd07c59a-9a3e-11e8-8849-059698342faa.png">
