### PR TITLE
added previous documentation of REST api to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,24 @@ You can also view `buildlog.text`, `httpd-access.log`, and `httpd-error.log` at 
 There are two types of Makeability Lab data: (i) uploaded files like PDFs, PowerPoint files, images, etc. and (ii) data that goes into the database (SQLite in local dev, PostgreSQL on production). Although we have both a test (makeability-test.cs) and a production server (makeability.cs), they are linked to the same backend data for both (i) and (ii).
 
 # Makeability Lab API
-TODO Johnson
+### What it does
+A script in the website automatically serializes some models specified in `serializers.py`. The data, in JSON format, is then rendered into an APIView and displayed in a webpage. The entire api framework is housed under the `/api/` url extension. Currently only publications and talks are serialized.
+
+### How to use
+There are two ways to call and retrieve the data:
+1.	List: will return all of the model objects in the data serialized into JSON
+2.	Detail: will return a specific object based on the primary key
+
+##### Publications:
+List: `https://makeabilitylab-test.cs.washington.edu/api/pubs/`
+<br>Detail: `https://makeabilitylab-test.cs.washington.edu/api/pubs/<pk: int>`
+
+##### Talks:
+List: `https://makeabilitylab-test.cs.washington.edu/api/talks/`
+<br>Detail: `https://makeabilitylab-test.cs.washington.edu/api/talks/<pk: int>`
+
+To request the pure json version, append `?format=json` to the end of the url. The data will then be rendered in complete JSON without the apiview.
+
 
 ## Uploaded Files
 All data/files uploaded to the Makeability Lab website via the admin interface (e.g., talks, publications) goes into the `/media` folder. Although typically you will not ever need to manually access this folder (except, for example, to view the `debug.log`), you can do so by ssh'ing into recycle.cs.washington.edu and cd to `/cse/web/research/makelab/www`. This files area is being mapped into the `/media` folder. This directory is shared by both https://makeabilitylab-test.cs.washington.edu/ and https://makeabilitylab.cs.washington.edu/.


### PR DESCRIPTION
The readme now displays documentation for what the rest api does and how to use it. 