### PR TITLE
Added a robots.txt for production site to allow all robots

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Disallow:


### PR DESCRIPTION
Resolves issue #546. A robots.txt has been created according to [this site](http://www.robotstxt.org/robotstxt.html). The User-agent parameter is used to set which robots this section applies to (* for all) and the Disallow parameter is used to exclude certain parts of the website from being accessed (/ for all). 

The file must be added to the top most level directory because robots query the url `https://<base_url>/robots.txt`, stripping off the portion following the first single slash and appending `/robots.txt` to the result.