### PR TITLE
Fix to appear bug

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -846,10 +846,7 @@ class Publication(models.Model):
 
     # Returns true if the publication date happens in the future (e.g., tomorrow or later)
     def to_appear(self):
-        ret = True
-        if date.today() > self.date:
-            ret = False
-        return ret
+        return self.date and self.date > date.today()
 
     def __str__(self):
         return self.title

--- a/website/models.py
+++ b/website/models.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 from django.db.models.signals import pre_delete, post_save, m2m_changed, post_delete
 from django.conf import settings
 
-from datetime import date
+from datetime import date, datetime, timedelta
 from django.utils import timezone
 from datetime import timedelta
 import datetime
@@ -846,7 +846,10 @@ class Publication(models.Model):
 
     # Returns true if the publication date happens in the future (e.g., tomorrow or later)
     def to_appear(self):
-        return self.date and self.date > date.today()
+        ret = True
+        if date.today() > self.date:
+            ret = False
+        return ret
 
     def __str__(self):
         return self.title

--- a/website/static/website/js/publications.js
+++ b/website/static/website/js/publications.js
@@ -276,10 +276,10 @@ function formatPublication(pub, filter) {
 		publicationData.find(".publication-acceptance-rate").css("display", "none");
 	}
 
-	if(pub.to_appear) {
-        publicationData.find(".publication-to-appear").css("display", "block");
+	if(pub.to_appear == true) {
+        publicationData.find(".publication-to-appear-text").css("display", "block");
     } else {
-    	publicationData.find(".publication-to-appear").css("display", "none");
+    	publicationData.find(".publication-to-appear-text").css("display", "none");
     }
 
     if(pub.keywords.length > 0)

--- a/website/templates/website/publications.html
+++ b/website/templates/website/publications.html
@@ -22,7 +22,7 @@
 <script src="{% static 'website/js/isotope.pkgd.min.js' %}"></script>
 <script src="{% static 'website/js/fixedSideBar.js' %}"></script>
 <script src="{% static 'website/js/filterBar.js' %}"></script>
-<script src="{% static 'website/js/publications.js' %}"></script>
+<script src="{% static 'website/js/publications.js' %}?version=1"></script>
 <script src="{% static 'website/js/jquery-ui.min.js' %}"></script>
 <script src="{% static 'website/js/citationPopover.js' %}"></script>
 


### PR DESCRIPTION
The pull request addresses issue #456. 
Before, all the publications were marked as "To Appear" due to a bug in the javascript that looked for an element tagged with the class="publication-to-appear" whereas the actually class of the "To Appear" text has class="publication-to-appear-text". 

Now, the "To Appear" text will only appear if the date of the publication object is greater than the time today. As shown below, the "To Appear" text can now be controlled.

[![Image from Gyazo](https://i.gyazo.com/fce9fc8c39a72fb5c6f5967068aecfad.png)](https://gyazo.com/fce9fc8c39a72fb5c6f5967068aecfad)