### PR TITLE
Auto rename files (now with CamelCase)

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -712,7 +712,8 @@ def update_file_name_talks(sender, instance, action, reverse, **kwargs):
         person = instance.get_person()
         name = person.last_name
         year = instance.date.year
-        title = instance.title.replace(' ', '')
+        title = ''.join(x for x in instance.title.title() if not x.isspace())
+        title = ''.join(e for e in title if e.isalnum())
 
         #change the pdf_file path to point to the renamed file
         instance.pdf_file.name = os.path.join('talks', name + '_' + title + '_' + str(year) + '.pdf')
@@ -861,7 +862,9 @@ def update_file_name_publication(sender, instance, action, reverse, **kwargs):
         person = instance.get_person()
         name = person.last_name
         year = instance.date.year
-        title = instance.title.replace(' ', '')
+        title = ''.join(x for x in instance.title.title() if not x.isspace())
+        title = ''.join(e for e in title if e.isalnum())
+
 
         #change the path of the pdf file to point to the new file name
         instance.pdf_file.name = os.path.join('publications', name + '_' + title + '_' + str(year) + '.pdf')
@@ -874,7 +877,7 @@ m2m_changed.connect(update_file_name_publication , sender=Publication.authors.th
 @receiver(pre_delete, sender=Publication)
 def publication_delete(sender, instance, **kwards):
     if instance.thumbnail:
-        instance.thumbnail.delete(False)
+        instance.thumbnail.delete(True)
     if instance.pdf_file:
         instance.pdf_file.delete(True)
     if instance.thumbnail:

--- a/website/models.py
+++ b/website/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from image_cropping import ImageRatioField
 from sortedm2m.fields import SortedManyToManyField
 from django.dispatch import receiver
-from django.db.models.signals import pre_delete, post_save, m2m_changed
+from django.db.models.signals import pre_delete, post_save, m2m_changed, post_delete
 from django.conf import settings
 
 from datetime import date
@@ -712,7 +712,7 @@ def update_file_name_talks(sender, instance, action, reverse, **kwargs):
         person = instance.get_person()
         name = person.last_name
         year = instance.date.year
-        title = instance.title.replace(' ', '_')
+        title = instance.title.replace(' ', '')
 
         #change the pdf_file path to point to the renamed file
         instance.pdf_file.name = os.path.join('talks', name + '_' + title + '_' + str(year) + '.pdf')
@@ -861,7 +861,7 @@ def update_file_name_publication(sender, instance, action, reverse, **kwargs):
         person = instance.get_person()
         name = person.last_name
         year = instance.date.year
-        title = instance.title.replace(' ', '_')
+        title = instance.title.replace(' ', '')
 
         #change the path of the pdf file to point to the new file name
         instance.pdf_file.name = os.path.join('publications', name + '_' + title + '_' + str(year) + '.pdf')


### PR DESCRIPTION
Previous version took the title and replaced all the spaces with underscores. This version will remove all the special characters and camel case the remaining words
Example:
New innovative research: Bread -> NewInnovativeResearchBread etc.