### PR TITLE
Updates permissions to give apache access to the entire /code directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ ADD . /code/
 ADD media /code/
 
 ##Our local user needs write access to a place
-RUN chown apache /code/website
+RUN chown apache /code
+# RUN chown apache /code/website
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.


### PR DESCRIPTION
Temporary workaround for #575. I'm not sure if this will work with our production site, but it gets rid of the `PermissionError: [Errno 13] Permission denied: '/code/static'` message locally (which is where the Django admin css is kept)