### PR TITLE
hides high school student department

### DIFF
--- a/website/templates/snippets/display_people_snippet.html
+++ b/website/templates/snippets/display_people_snippet.html
@@ -23,8 +23,10 @@
                     </a>
                     {{ member.get_start_date_short }} - {{ member.get_end_date_short }}<br/>
                     {{ member.title }}<br/>
-                    {{ member.department }}<br/>
-                    {{ member.school }}
+                    {% if member.title == 'High School Student' %}
+                    {% else %}
+                        {{ member.department }}<br/>
+                    {% endif %}
                 </div>
                 <div class="sortingAndFiltering" style="display:none">
                     <!-- special case for professors since each type of prof does not get their own category -->


### PR DESCRIPTION
Addresses issue #506 

Now, the department field of the position model is not required, and on the people page of the website, high school students will not display a department.

[![Image from Gyazo](https://i.gyazo.com/65a0d5799254535696048cc178dbac25.png)](https://gyazo.com/65a0d5799254535696048cc178dbac25)