### PR TITLE
Added Additional API Support

### DIFF
--- a/website/serializers.py
+++ b/website/serializers.py
@@ -1,11 +1,22 @@
 from rest_framework import serializers
-from website.models import Person, Publication, Talk, Video, Project, Project_umbrella
+from website.models import Person, Publication, Talk, Video, Project, News
+
+'''
+https://stackoverflow.com/questions/38366605/exclude-a-field-from-django-rest-framework-serializer
+to exclude a field from serialization, use the exclude feature
+example: exclude = ('field1',)
+
+More in depth explanation of how to use Django Rest Framework serializers found here:
+http://www.django-rest-framework.org/tutorial/1-serialization/
+
+the serializer will automatically scan relations between objects up to a certain depth and pass it to the JSON
+http://www.django-rest-framework.org/api-guide/serializers/#specifying-nested-serialization
+'''
+
 
 class PublicationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Publication
-        #the serializer will automatically scan relations between objects up to a certain depth and pass it to the JSON
-        #http://www.django-rest-framework.org/api-guide/serializers/#specifying-nested-serialization
         depth = 10
         #many to many: authors, projects, project_umbrellas,
         #one to one:video
@@ -17,5 +28,34 @@ class TalkSerializer(serializers.ModelSerializer):
     class Meta:
         model = Talk
         #Many to many fields: projects, project_umbralla, keywords, speakers
+        fields = '__all__'
+        depth = 10
+
+
+class PersonSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Person
+        fields = '__all__'
+        depth = 10
+
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = '__all__'
+        depth = 10
+
+class VideoSerializer(serializers.ModelSerializer):
+    project = ProjectSerializer()
+    class Meta:
+        model = Video
+        fields = '__all__'
+        depth = 10
+
+class NewsSerializer(serializers.ModelSerializer):
+    author = PersonSerializer()
+    class Meta:
+        model = News
         fields = '__all__'
         depth = 10

--- a/website/urls.py
+++ b/website/urls.py
@@ -20,6 +20,14 @@ urlpatterns = [
     url(r'^api/talks/(?P<pk>[0-9])/$', views.TalkDetail.as_view(), name='api_talk'),
     url(r'^api/pubs/$', views.PubsList.as_view(), name='api_all_pubs'),
     url(r'^api/pubs/(?P<pk>[0-9])/$', views.PubsDetail.as_view(), name='api_pub'),
+    url(r'^api/people/$', views.PersonList.as_view(), name='api_all_people'),
+    url(r'^api/people/(?P<pk>[0-9])/$', views.PersonDetail.as_view(), name='api_person'),
+    url(r'^api/news/$', views.NewsList.as_view(), name='api_all_news'),
+    url(r'^api/news/(?P<pk>[0-9])/$', views.NewsDetail.as_view(), name='api_news'),
+    url(r'^api/video/$', views.VideoList.as_view(), name='api_all_videos'),
+    url(r'^api/video/(?P<pk>[0-9])/$', views.VideoDetail.as_view(), name='api_video'),
+    url(r'^api/project/$', views.ProjectList.as_view(), name='api_all_projects'),
+    url(r'^api/project/(?P<pk>[0-9])/$', views.ProjectDetail.as_view(), name='api_project'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/website/views.py
+++ b/website/views.py
@@ -18,7 +18,7 @@ from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from website.serializers import TalkSerializer, PublicationSerializer
+from website.serializers import TalkSerializer, PublicationSerializer, PersonSerializer, ProjectSerializer, VideoSerializer, NewsSerializer
 
 # The Google Analytics stuff is all broken now. It was originally used to track the popularity
 # of pages, projects, and downloads. Not sure what we should do with it now.
@@ -114,6 +114,103 @@ class PubsDetail(APIView):
         pub = self.get_object(pk)
         pub.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class PersonList(APIView):
+    '''
+    List all talks, or create a new talk
+    '''
+    def get(self, request, format = None):
+        people = Person.objects.all()
+        serializer = PersonSerializer(people,many=True,context={'request': request})
+        return Response(serializer.data)
+
+class PersonDetail(APIView):
+    """
+    Retrieve, update or delete a snippet instance.
+    """
+    def get_object(self, pk):
+        try:
+            return Person.objects.get(pk=pk)
+        except Person.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        person = self.get_object(pk)
+        serializer = PersonSerializer(person)
+        return Response(serializer.data)
+
+class NewsList(APIView):
+    '''
+    List all talks, or create a new talk
+    '''
+    def get(self, request, format = None):
+        news = News.objects.all()
+        serializer = NewsSerializer(news,many=True,context={'request': request})
+        return Response(serializer.data)
+
+class NewsDetail(APIView):
+    """
+    Retrieve, update or delete a snippet instance.
+    """
+    def get_object(self, pk):
+        try:
+            return News.objects.get(pk=pk)
+        except News.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        news = self.get_object(pk)
+        serializer = NewsSerializer(person)
+        return Response(serializer.data)
+
+class VideoList(APIView):
+    '''
+    List all talks, or create a new talk
+    '''
+    def get(self, request, format = None):
+        videos = Video.objects.all()
+        serializer = VideoSerializer(videos,many=True,context={'request': request})
+        return Response(serializer.data)
+
+class VideoDetail(APIView):
+    """
+    Retrieve, update or delete a snippet instance.
+    """
+    def get_object(self, pk):
+        try:
+            return Video.objects.get(pk=pk)
+        except Video.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        video = self.get_object(pk)
+        serializer = VideoSerializer(video)
+        return Response(serializer.data)
+
+class ProjectList(APIView):
+    '''
+    List all talks, or create a new talk
+    '''
+    def get(self, request, format = None):
+        projects = Project.objects.all()
+        serializer = ProjectSerializer(projects,many=True,context={'request': request})
+        return Response(serializer.data)
+
+class ProjectDetail(APIView):
+    """
+    Retrieve, update or delete a snippet instance.
+    """
+    def get_object(self, pk):
+        try:
+            return Project.objects.get(pk=pk)
+        except Project.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        project = self.get_object(pk)
+        serializer = ProjectSerializer(project)
+        return Response(serializer.data)
 
 # Every view is passed settings.DEBUG. This is used to insert the appropriate google analytics tracking when in
 # production, and to not include it for development


### PR DESCRIPTION
Addresses issue #541 

Before the API only supported talks and publications for the importtalks and importpubs command; however, now the api will also serialize and return the JSON data for News, Projects, Videos, and Person objects. 