### PR TITLE
Resolves #603: Update how url names are created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ ADD . /code/
 ADD media /code/
 
 ##Our local user needs write access to a website and static files
-RUN chown -R apache /code/website
-
+RUN chown -R apache /code/
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.

--- a/website/models.py
+++ b/website/models.py
@@ -29,6 +29,15 @@ def capitalize_title(s, exceptions):
 #Standard list of words to not capitalize in a sentence
 articles = ['a', 'an', 'and', 'as', 'at', 'but', 'by', 'for', 'from', 'is', 'of', 'on', 'or', 'nor', 'the', 'to', 'up', 'yet']
 
+# Special character mappings
+special_chars = {
+    'ã': 'a', 'à': 'a', 'â': 'a',
+    'é': 'e', 'è': 'e', 'ê': 'e',
+    'ñ': 'n', 'ń': 'n',
+    'ö': 'o', 'ô': 'o',
+    'û': 'u', 'ü': 'u', 'ù': 'u'
+}
+
 # Simple check to seee if a file is an image. Not strictly necessary but included for safety
 def isimage(filename):
     """true if the filename's extension is in the content-type lookup"""
@@ -258,7 +267,17 @@ class Person(models.Model):
         star_wars_dir = os.path.join(dir, get_random_starwars(dir))
         image_choice = File(open(star_wars_dir, 'rb'))
         # automatically set url_name field
-        self.url_name = (self.first_name + self.last_name).lower().replace(' ', '')
+
+        # Substitute any common special characters. I haven't found a better automatic way to do
+        # this, so we are manually mapping 'common' special characters.
+        url_name_cleaned = (self.first_name + self.last_name).lower()
+        for c in url_name_cleaned:
+            if bool(re.search('[^a-zA-Z]', c)) and c in special_chars:
+                url_name_cleaned = url_name_cleaned.replace(c, special_chars.get(c))
+
+        # Finally, clean remaining characters (EX: dashes, periods).
+        url_name_cleaned = re.sub('[^a-zA-Z]', '', url_name_cleaned)
+        self.url_name = url_name_cleaned
 
         if not self.image:
             self.image = image_choice


### PR DESCRIPTION
Resolves #603 

This pull request adds a regex expression for creating `url_name` that hopefully prevents future problems with names using non-ASCII characters.

Here's what we currently do to create url names:
* Add the first and last names together, turn everything into lowercase
* Go through each character in the url name, and check for any special characters (non a-z/A-Z characters)
    * If there is a special character, check to see if we are mapping it to anything. (EX: ö gets mapped to o).
* Go through the name a final time, and remove any remaining regex characters. This is in case there are hyphenated names / names with periods in them.

Example:

| First name | Last name | Final url name |
| ----------- | --------- | -------------- |
| aileén | zeng- | aileenzeng | 

I also made a small change to the Dockerfile. I noticed that we didn't have the correct permissions to run `collectstatic` with our previous version.