### PR TITLE
Resolves #638: Local site not running

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -90,7 +90,7 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'filename': '/code/media/debug.log',
             'maxBytes': 1024*1024*10, # 10 MB
             'backupCount': 5,


### PR DESCRIPTION
Resolves #638.

Fixed `FileHandler` --> `RotatinFileHandler` in settings.