### PR TITLE
Resolves #646: Shrinks Docker build context.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 website/migrations/
+media/

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN pip install -r requirements.txt
 
 # Add the current directory to /code/
 ADD . /code/
-ADD media /code/
 
 ##Our local user needs write access to a website and static files
 RUN chown -R apache /code/


### PR DESCRIPTION
Resolves #646.

My testing hasn't been super thorough since I don't have very much stuff in my media directory right now. I think it is fine to exclude `media` from the build context because we have a volume mount for `media` in our run command.

Testing instructions:
* Pull `646-shrink-docker-build-context`
* Run `make run` again. The build context should be maybe ~250MB. Visit the webpage to make sure that nothing is broken (maybe try clicking on some of the `media`.
* Try adding another publication/talk - check to see that it uploaded correctly