### PR TITLE
fixes recent video and talks headers in project pages to match other headings

### DIFF
--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -152,7 +152,7 @@
     <div class="row no-margin" id="below-sidebar">
         <div class="row row-adjust-margins">
             {% if videos %}
-            <h3 class="news-type-lable"><b>Recent Videos</b></h3>
+            <h3 class="news-type-lable">Recent Videos</h3>
             {% endif %}
             {% for video in videos %}
                 {% include "snippets/display_video_snippet.html" %}
@@ -160,7 +160,7 @@
         </div>
         <div class="row row-adjust-margins">
             {% if talks %}
-                <h3 class="news-type-label"><b>Talks</b></h3>
+                <h3 class="news-type-label">Talks</h3>
             {% endif %}
 
             {% for talk in talks %}


### PR DESCRIPTION
fixes #693 

There was a bold tag in surrounding the text in the h3 tag. It affected both recent videos and talks.
Should be good now.