### PR TITLE
Fixes individual news article title

### DIFF
--- a/website/templates/snippets/display_short_carousel_snippet.html
+++ b/website/templates/snippets/display_short_carousel_snippet.html
@@ -14,8 +14,8 @@
             {#  | title is built into Django, how handy! see: https://stackoverflow.com/questions/14268342/make-the-first-letter-uppercase-inside-a-django-template #}
 {#            <div class="overlay-title">{{ request.path|title|slice:"1:"|slice:":-1" }}</div>#}
             <div class="overlay-title">
-                {% if page_title %}
-                    {{ page_title }}
+                {% if news.title %}
+                    {{ news.title }}
                 {% else %}
                     {{ request.path|get_url_page|title }}
                 {% endif %}

--- a/website/templates/snippets/display_short_carousel_snippet.html
+++ b/website/templates/snippets/display_short_carousel_snippet.html
@@ -16,6 +16,8 @@
             <div class="overlay-title">
                 {% if news.title %}
                     {{ news.title }}
+                {% elif page_title %}
+                    {{ page_title }}
                 {% else %}
                     {{ request.path|get_url_page|title }}
                 {% endif %}


### PR DESCRIPTION
fixes #685 

I just switched 'page_title' to 'news.title' in the if statement.
This worked as every page(besides the news.html) grabs the overlay title from the url.
May want to look into a better solution down the road.