### PR TITLE
fixes the bug that shifted recent projects to the right on a member page

### DIFF
--- a/website/static/website/css/member.css
+++ b/website/static/website/css/member.css
@@ -20,3 +20,9 @@
 .content-container {
     margin-top: 25px;
 }
+
+.individual-project-listing {
+    padding-left: 0;
+    margin-bottom: 20px;
+    padding-right: 30px;
+}

--- a/website/templates/snippets/display_project_snippet.html
+++ b/website/templates/snippets/display_project_snippet.html
@@ -6,7 +6,7 @@
 {% load cropping %}
 {% load ml_tags %}
 
-<div class="col-ts-12 col-xs-6 col-sm-4 col-lg-3" style="margin-bottom:20px">
+<div class="col-ts-12 col-xs-6 col-sm-4 col-lg-3 individual-project-listing">
     <a href="{% url 'website:project' project.short_name %}">
         <div style="background: white; width:100%; height: 180px; contain: content;">
             <img style="width:100%; height: auto; position: relative;top: 50%; left: 50%;transform: translate(-50%,-50%);object-fit: cover"

--- a/website/templates/website/member.html
+++ b/website/templates/website/member.html
@@ -129,40 +129,43 @@
                         </div>
                     {% endif %}
                 </div>
-
-                <div id="makelab-recent-projects" class="container-fluid makelab-content-container">
-                    {% if project_roles %}
-                        <h3 class="news-type-label" style="margin-top:25px"><b>Projects</b></h3>
-                        {% for project_role in project_roles %}
-                            {% include "snippets/display_project_snippet.html" with project=project_role.project %}
-                        {% endfor %}
-
-                    {% endif %}
-                </div>
-                <div id="makelab-recent-projects" class="container-fluid makelab-content-container">
-                    {% if publications %}
-                        <div class="row">
-                            <h3 class="news-type-label"><b>Publications</b></h3>
-                            <div class="col-xs-12 col-md-10">
-                                {% for pub in publications %}
-                                    {% include "snippets/display_pub_snippet.html" %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                    {% endif %}
-                </div>
-
-                <div id="makelab-recent-projects" class="container-fluid makelab-content-container">
-                    {% if talks %}
-                        <div class="row">
-                            <h3 class="news-type-label"><b>Talks</b></h3>
+                <div class="col-xs-12 col-md-10 col-md-pull-2 landing-content">
+                    <div id="makelab-recent-projects" class="makelab-content-container">
+                        {% if project_roles %}
                             <div class="row">
-                                {% for talk in talks %}
-                                    {% include "snippets/display_talk_snippet.html" %}
+                                <h3 class="news-type-label"><b>Projects</b></h3>
+                                {% for project_role in project_roles %}
+                                    {% include "snippets/display_project_snippet.html" with project=project_role.project %}
                                 {% endfor %}
                             </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
+
+                    <div id="makelab-recent-publications" class="makelab-content-container">
+                        {% if publications %}
+                            <div class="row">
+                                <h3 class="news-type-label"><b>Publications</b></h3>
+                                <div class="col-xs-12 col-md-10">
+                                    {% for pub in publications %}
+                                        {% include "snippets/display_pub_snippet.html" %}
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div id="makelab-recent-talks" class="makelab-content-container">
+                        {% if talks %}
+                            <div class="row">
+                                <h3 class="news-type-label"><b>Talks</b></h3>
+                                <div class="row">
+                                    {% for talk in talks %}
+                                        {% include "snippets/display_talk_snippet.html" %}
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
fixes #670 

<img width="1440" alt="screen shot 2018-12-19 at 8 54 31 pm" src="https://user-images.githubusercontent.com/33988444/50264648-6b500d00-03d0-11e9-9cb9-ea4ddff1db5e.png">
