### PR TITLE
Sponsor Hyperlink Error

### DIFF
--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -47,10 +47,15 @@
 		    <b>Sponsors: </b>
 		    {% endifequal %}
 		    {% for sponsor in project.sponsors.all %}
-		    <a href="{{sponsor.url}}">
-			<img src="{{sponsor.icon}}" class="sponsor-icon">
-			<span class="sponsor-name">{{sponsor.name}}</span>
-		    </a>
+                {%  if sponsor.url %}
+                    <a href="{{sponsor.url}}" target="_blank">
+                        <img src="{{sponsor.icon}}" class="sponsor-icon">
+                        <span class="sponsor-name">{{sponsor.name}}</span>
+                    </a>
+                {% else %}
+                    <img src="{{sponsor.icon}}" class="sponsor-icon">
+                    <span class="sponsor-name">{{sponsor.name}}</span>
+                {% endif %}
 		    {% endfor %}
 		    <br/>
 		    <b>Keywords: </b>


### PR DESCRIPTION
fixes #629 

Sponsors that do not have urls, will not be hyperlinked. Sponsors that are hyperlinked will open in a new tab.