### PR TITLE
fixes filter scrolling bar

### DIFF
--- a/website/static/website/js/fixedSideBar.js
+++ b/website/static/website/js/fixedSideBar.js
@@ -88,10 +88,6 @@
 		    		sideBar.css('position', 'absolute');
 		    		sideBar.css ('top', initOffset);
 		    		sideBar.css('left', 0);
-		    	} else {
-		    		sideBar.css('position', 'absolute');
-		    		sideBar.css('top', bottomOffset) ;
-		    		sideBar.css('left', 0);
 		    	}
 		    }
 	}


### PR DESCRIPTION
#631 

I took out three lines of code that were causing the bug. I think what they were trying to do was prevent the filter bar from scrolling under the footer. However, in the Makeability test website(the most recent version of the footer) missing these three lines did not seem to make a difference.