### PR TITLE
Fixes the mouse over image to not show a blank

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -152,7 +152,7 @@ h5 {
     opacity: 1!important;
 }
 
-.easter-egg-hide, .easter-egg-col:hover > img {
+.easter-egg-hide {
     opacity: 0;
 }
 

--- a/website/static/website/css/member.css
+++ b/website/static/website/css/member.css
@@ -11,6 +11,14 @@
     overflow: hidden;
 }
 
+.easter-egg-col:hover > img {
+    opacity: 0;
+}
+
+.easter-egg-col:hover .overlay-easter-egg {
+    opacity: 1;
+}
+
 .header-icon {
     height: 25px;
     width: 25px;


### PR DESCRIPTION
#727 
Fixes the mouse over image to not show a blank. Also on a individual person page it will no longer show a blank as well.