### PR TITLE
Removes added vertical space between names and images

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -158,7 +158,6 @@ h5 {
 
 .easter-egg-col {
     position: relative;
-	margin-bottom: 18px;
 }
 
 .overlay-easter-egg {

--- a/website/static/website/css/member.css
+++ b/website/static/website/css/member.css
@@ -11,6 +11,10 @@
     overflow: hidden;
 }
 
+.easter-egg-col {
+    margin-bottom: 18px;
+}
+
 .header-icon {
     height: 25px;
     width: 25px;


### PR DESCRIPTION
#728 
Removes added vertical space between name and image of person. It still maintains the added margin on the individual member page

Before:
<img width="1440" alt="screen shot 2019-01-03 at 6 09 39 pm" src="https://user-images.githubusercontent.com/33988444/50670813-c4986e80-0f82-11e9-9c28-ff21067281af.png">

After:
<img width="1440" alt="screen shot 2019-01-03 at 6 05 23 pm" src="https://user-images.githubusercontent.com/33988444/50670788-a92d6380-0f82-11e9-957b-94f3cb329ccb.png">
