### PR TITLE
shows links beneath talks on hover

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -342,6 +342,10 @@ h5 {
 	color: black;
 }
 
+.talk-column .pub-download-links {
+	opacity: 0;
+}
+
 .pub-download-links {
     font-size: 7pt;
     color: gray;

--- a/website/static/website/css/talks.css
+++ b/website/static/website/css/talks.css
@@ -167,3 +167,7 @@
 .talk-citation-link {
 	cursor:pointer;
 }
+
+.talk-column:hover .pub-download-links {
+	opacity: 1;
+}


### PR DESCRIPTION
#738 

If the functionality looks good, we may want to consider adjusting the padding/margin below each talk after merging.

![hide](https://user-images.githubusercontent.com/33988444/50719734-c121e780-1055-11e9-8e65-b503b00c5461.gif)
