### PR TITLE
Fixes talks in mobile view as well as hover on homepage

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -346,6 +346,10 @@ h5 {
 	opacity: 0;
 }
 
+.talk-column:hover .pub-download-links {
+	opacity: 1;
+}
+
 .pub-download-links {
     font-size: 7pt;
     color: gray;

--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -747,6 +747,12 @@ h5 {
     float: left;
 }
 
+@media (max-width: 550px) {
+	.talk-column .pub-download-links {
+		opacity: 1;
+	}
+}
+
 @media (min-width: 768px) {
     .col-sm-5ths {
         width: 20%;

--- a/website/static/website/css/talks.css
+++ b/website/static/website/css/talks.css
@@ -167,7 +167,3 @@
 .talk-citation-link {
 	cursor:pointer;
 }
-
-.talk-column:hover .pub-download-links {
-	opacity: 1;
-}


### PR DESCRIPTION
#738 
address the concerns you had after the first merge of this issue. It now has shows the links beneath talks all the time in mobile view.
![talk](https://user-images.githubusercontent.com/33988444/50815948-e459ca80-12d3-11e9-9bc8-52c7745ee44d.gif)

