### PR TITLE
paper titles are hyperlinked on pubs page

### DIFF
--- a/website/static/website/js/publications.js
+++ b/website/static/website/js/publications.js
@@ -240,6 +240,7 @@ function formatPublication(pub, filter) {
 	publicationData.find(".publication-id").html(pub.id);
 	publicationData.find(".publication-thumbnail-link").attr("href", pub.pdf);
 	publicationData.find(".publication-thumbnail-image").attr("src", pub.thumbnail);
+	publicationData.find(".publication-title-link").attr("href", pub.pdf);
 	publicationData.find(".artifact-title").html(addHighlight(pub.title));
 
 	var authors = publicationData.find(".publication-authors");

--- a/website/templates/website/publications.html
+++ b/website/templates/website/publications.html
@@ -125,7 +125,9 @@
                     </a>
                 </div>
                 <div class="publication-info">
-                    <p class="artifact-title">Paper Title</p>
+                    <a href="link" class="publication-title-link">
+                        <p class="artifact-title">Paper Title</p>
+                    </a>
                     <p class="publication-authors">
                         <span class="publication-author"><a href="link">Author Name</a>,&nbsp;</span>
                         <span class="publication-author-last"><a href="link">Author Name</a></span>


### PR DESCRIPTION
#749 
It's not blue or underlined as shown in the before and after.

Before:
![screen shot 2019-01-10 at 12 23 27 pm](https://user-images.githubusercontent.com/33988444/50994979-8e9f4100-14d2-11e9-8910-cb685b7c27b3.png)
After:
![screen shot 2019-01-10 at 12 16 50 pm](https://user-images.githubusercontent.com/33988444/50994906-57c92b00-14d2-11e9-91b7-58a49fa682e8.png)
