### PR TITLE
fixes department abbreviation for HCDE and CSE. Removes added space after member title

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -419,15 +419,18 @@ class Position(models.Model):
         department_keywords_normal = ["building science", "architecture", "bioengineering"]
         department_keywords_map = ["BuildSci", "Arch", "BIOE"]
         abbrv = ""
-        if "computer science" in self.department.lower():
-            abbrv += 'CS,'
-        elif "computer science" in self.department.lower() and "engineering" in self.department.lower():
+        if "computer science" in self.department.lower() and "engineering" in self.department.lower():
             abbrv += 'CSE,'
+        elif "computer science" in self.department.lower():
+            abbrv += 'CS,'
         elif 'computer engineering' in self.department.lower():
             abbrv += 'CprE,'
 
         if "information" in self.department.lower() or "ischool" in self.department.lower():
             abbrv += 'iSchool,'
+
+        if "hcde" in self.department.lower() or "human centered design" in self.department.lower() and "engineering" in self.department.lower():
+            abbrv += 'HCDE,'
 
         for keyword in department_keywords_normal:
             counter = 0

--- a/website/templates/website/member.html
+++ b/website/templates/website/member.html
@@ -42,12 +42,8 @@
                     {% with person.get_latest_position as position %}
                         {% if position %}
                             <p class="person-title-text">
-                                {{ position.title }}
-                                {% if position.is_high_school %}
-                                {% else %}
-                                    , {{ position.get_department_abbreviated }}
-                                {% endif %}
-                            <br/>
+                                {{ position.title }}{% if not position.is_high_school %}, {{ position.get_department_abbreviated }}{% endif %}
+                                <br/>
                                 {{ position.school }}
                             </p>
                         {% endif %}


### PR DESCRIPTION
#756 
I found an additional error with members who selected Computer Science and Engineering. They're department abbreviation would just be "CS". This was caused from a wrongly structured 'if else' statement. I added a department abbreviation for HCDE so it can be any of the listed below when entered into Django department field:
1. HCDE
2. Human Centered Design and Engineering
3. Human Centered Design & Engineering

Lastly, the awkward space was removed from between title and the comma before department.

Before:
![screen shot 2019-01-14 at 11 12 44 pm](https://user-images.githubusercontent.com/33988444/51164729-bedc3c00-1852-11e9-8c7a-c797f1c0ca8f.png)
After:
![screen shot 2019-01-14 at 11 12 50 pm](https://user-images.githubusercontent.com/33988444/51164742-c6034a00-1852-11e9-8e61-baf27f56d8dc.png)
Before: 
![screen shot 2019-01-14 at 11 14 39 pm](https://user-images.githubusercontent.com/33988444/51164768-e16e5500-1852-11e9-8915-22dd5db017bf.png)
After:
![screen shot 2019-01-14 at 11 14 07 pm](https://user-images.githubusercontent.com/33988444/51164779-e8956300-1852-11e9-9b73-f38d3a083afc.png)


