### PR TITLE
Address Marianne's long name

### DIFF
--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -34,7 +34,7 @@ h4 {
 }
 
 h5 {
-	font-size: large;
+	font-size: 1.2em;
 	font-weight: bold;
 	margin:0;
 	padding:0;
@@ -158,6 +158,12 @@ h5 {
 
 .easter-egg-col {
     position: relative;
+}
+
+.easter-egg-name {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .overlay-easter-egg {


### PR DESCRIPTION
#756 
Her name no longer drops to two lines when the screen in 15inch. When in a smaller screen view(~500px), the best option was to either have text overflow in ellipse or clip. I can look into js if we want it to auto adjust the text if it's longer than the div when the screen is being resized, but this is the quick fix we talked about in our meeting.
Before:
<img width="786" alt="screen shot 2019-01-21 at 7 31 26 pm" src="https://user-images.githubusercontent.com/33988444/51510925-07947780-1db4-11e9-951f-750fda6eae2e.png">
After:
<img width="759" alt="screen shot 2019-01-21 at 7 24 51 pm" src="https://user-images.githubusercontent.com/33988444/51510929-0f541c00-1db4-11e9-802d-c5b3769769fc.png">
Before(~500px):
<img width="243" alt="screen shot 2019-01-21 at 7 31 09 pm" src="https://user-images.githubusercontent.com/33988444/51510954-2e52ae00-1db4-11e9-9c3f-8efa2834a9ed.png">
After Ellipse(~500px):
<img width="296" alt="screen shot 2019-01-21 at 7 25 15 pm" src="https://user-images.githubusercontent.com/33988444/51510934-1713c080-1db4-11e9-9a9c-a526973126ae.png">
After Clip(~500px):
<img width="261" alt="screen shot 2019-01-21 at 7 26 06 pm" src="https://user-images.githubusercontent.com/33988444/51510964-3579bc00-1db4-11e9-8d20-f5aca9ce0497.png">
