### PR TITLE
fixes the visual project picture from not split with the about text

### DIFF
--- a/website/static/website/css/project.css
+++ b/website/static/website/css/project.css
@@ -70,9 +70,9 @@
 }
 
 .header-visual-caption {
+    font-size: smaller;
     margin-top: 0px;
     color: #7F7F7F;
-    float: right;
     max-width: 535px;
 }
 

--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -126,7 +126,7 @@
 
                             <p style="font-weight: bold; margin:0px;">{{ header.title }}</p>
                             {% if header.caption %}
-                               <p style="font-size: smaller;"> {{ header.caption }}</p>
+                               <p class="header-visual-caption"> {{ header.caption }}</p>
                             {% endif %}
                         {% endwith %}
                     {% else %}


### PR DESCRIPTION
#769 
I edited the css a bit and included a class that should have probably been included on the caption. It was not split screening the with "about" text because the caption had no maximum width.

Before:
![screen shot 2019-01-23 at 7 21 17 pm](https://user-images.githubusercontent.com/33988444/51652359-2c1f5980-1f44-11e9-8ad2-1402119b86a0.png)
After:
![screen shot 2019-01-23 at 7 13 42 pm](https://user-images.githubusercontent.com/33988444/51652354-29246900-1f44-11e9-8ac7-69f18f0cfca6.png)
Before:
![screen shot 2019-01-23 at 7 21 08 pm](https://user-images.githubusercontent.com/33988444/51652386-4bb68200-1f44-11e9-9068-35a17a1e5634.png)
After:
![screen shot 2019-01-23 at 7 13 56 pm](https://user-images.githubusercontent.com/33988444/51652402-52dd9000-1f44-11e9-90fc-3a45f38c3f91.png)
Before:
![screen shot 2019-01-23 at 7 20 41 pm](https://user-images.githubusercontent.com/33988444/51652408-58d37100-1f44-11e9-8048-6e103caf5ceb.png)
After:
![screen shot 2019-01-23 at 7 19 39 pm](https://user-images.githubusercontent.com/33988444/51652414-5c66f800-1f44-11e9-8ee2-da983ef04f16.png)





