### PR TITLE
CSS Cleanup Part 1 and 2

### DIFF
--- a/website/static/website/css/autocomplete.css
+++ b/website/static/website/css/autocomplete.css
@@ -1,9 +1,9 @@
 .ui-autocomplete {
-    font-size: 12px;
-    font-family: adelle regular;
+  font-size: 12px;
+  font-family: adelle regular;
 }
 
 .ui-menu .ui-menu-item {
-    font-size: 12px;
-    font-family: adelle regular;
+  font-size: 12px;
+  font-family: adelle regular;
 }

--- a/website/static/website/css/backtop.css
+++ b/website/static/website/css/backtop.css
@@ -1,93 +1,83 @@
 /**** Automatic Show/Hide Scroll-Up Up Arrow ****/
+
 #back-top {
-    position: fixed;
-    bottom: 10px;
-    left: 25px;
-    z-index: 1000;
+  position: fixed;
+  bottom: 10px;
+  left: 25px;
+  z-index: 1000;
 }
 
-@media (max-width: 768px){
-    #back-top a {
-	width: 25px;
-	display: block;
-	text-align: center;
-	font: 5px/100% Arial, Helvetica, sans-serif;
-	text-transform: uppercase;
-	text-decoration: none;
-	color: rgba(0,0,0,0.7);
-	
-	/* transition */
-	-webkit-transition: 1s;
-	-moz-transition: 1s;
-	transition: 1s;
-    }
+@media (max-width: 768px) {
+  #back-top a {
+    width: 25px;
+    display: block;
+    text-align: center;
+    font: 5px/100% Arial, Helvetica, sans-serif;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: rgba(0,0,0,0.7);
+    /* transition */
+    -webkit-transition: 1s;
+    -moz-transition: 1s;
+    transition: 1s;
+  }
 
-    #back-top span {
-	width: 25px;
-	height: 25px;
-	display: block;
-	margin-bottom: 7px;
-	background: rgba(0,0,0,0.4) url(../img/up-arrow.png) no-repeat center center;
-	background-size: 100% 100%;
-	
-	/* rounded corners */
-	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
-	border-radius: 5px;
-	
-	/* transition */
-	-webkit-transition: 1s;
-	-moz-transition: 1s;
-	transition: 1s;
-    }
-
+  #back-top span {
+    width: 25px;
+    height: 25px;
+    display: block;
+    margin-bottom: 7px;
+    background: rgba(0,0,0,0.4) url(../img/up-arrow.png) no-repeat center center;
+    background-size: 100% 100%;
+    /* rounded corners */
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    /* transition */
+    -webkit-transition: 1s;
+    -moz-transition: 1s;
+    transition: 1s;
+  }
 }
 
-@media (min-width: 769px){
-    #back-top a {
-	width: 75px;
-	display: block;
-	text-align: center;
-	font: 11px/100% Arial, Helvetica, sans-serif;
-	text-transform: uppercase;
-	text-decoration: none;
-	color: rgba(0,0,0,0.7);
-	
-	/* transition */
-	-webkit-transition: 1s;
-	-moz-transition: 1s;
-	transition: 1s;
-    }
+@media (min-width: 769px) {
+  #back-top a {
+    width: 75px;
+    display: block;
+    text-align: center;
+    font: 11px/100% Arial, Helvetica, sans-serif;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: rgba(0,0,0,0.7);
+    /* transition */
+    -webkit-transition: 1s;
+    -moz-transition: 1s;
+    transition: 1s;
+  }
 
-    #back-top span {
-	width: 75px;
-	height: 75px;
-	display: block;
-	margin-bottom: 7px;
-	background: rgba(0,0,0,0.4) url(../img/up-arrow.png) no-repeat center center;
-	
-	/* rounded corners */
-	-webkit-border-radius: 15px;
-	-moz-border-radius: 15px;
-	border-radius: 15px;
-	
-	/* transition */
-	-webkit-transition: 1s;
-	-moz-transition: 1s;
-	transition: 1s;
-    }
-    
+  #back-top span {
+    width: 75px;
+    height: 75px;
+    display: block;
+    margin-bottom: 7px;
+    background: rgba(0,0,0,0.4) url(../img/up-arrow.png) no-repeat center center;
+    /* rounded corners */
+    -webkit-border-radius: 15px;
+    -moz-border-radius: 15px;
+    border-radius: 15px;
+    /* transition */
+    -webkit-transition: 1s;
+    -moz-transition: 1s;
+    transition: 1s;
+  }
 }
-
-
 
 #back-top a:hover {
-    color: rgba(0,0,0,0.7);
+  color: rgba(0,0,0,0.7);
 }
 
 /* arrow icon (span tag) */
 
-
 #back-top a:hover span {
-    background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.7);
 }

--- a/website/static/website/css/base.css
+++ b/website/static/website/css/base.css
@@ -1,203 +1,205 @@
 @font-face {
-	font-family: roboto;
-	src: url(../fonts/roboto/Roboto-Thin.ttf);
+  font-family: roboto;
+  src: url(../fonts/roboto/Roboto-Thin.ttf);
 }
 
 @font-face {
-	font-family: roboto-bold;
-	src: url(../fonts/roboto/Roboto-Light.ttf);
+  font-family: roboto-bold;
+  src: url(../fonts/roboto/Roboto-Light.ttf);
 }
 
 /* General styles */
-body {
-	font-family: 'Raleway', sans-serif;
-}
 
-hr {
-	margin-top:0;
+body {
+  font-family: 'Raleway', sans-serif;
 }
 
 h1 {
-	font-family: 'Raleway', sans-serif;
-	font-weight: 700;
-	font-size: 36px;
-	margin-bottom:0;
-	padding-bottom:0;
-	margin-left:-1px;
+  font-family: 'Raleway', sans-serif;
+  font-weight: 700;
+  font-size: 36px;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  margin-left: -1px;
 }
 
 h4 {
-	font-size: 18px;
-	color: #464D59;
-	margin-top:0;
-	padding-top:0;
+  font-size: 18px;
+  color: #464D59;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 h5 {
-	font-size: 1.2em;
-	font-weight: bold;
-	margin:0;
-	padding:0;
+  font-size: 1.2em;
+  font-weight: bold;
+  margin: 0;
+  padding: 0;
 }
 
 .thumbnail {
-	margin-bottom:0;
+  margin-bottom: 0;
 }
 
 .popover {
-	width: 50vw;
-    min-width: 300px;
-    max-width: 100vw;
+  width: 50vw;
+  min-width: 300px;
+  max-width: 100vw;
 }
 
 .item-info {
-	margin:0;
-	padding-top:10px;
-	padding-bottom:50px;
+  margin: 0;
+  padding-top: 10px;
+  padding-bottom: 50px;
 }
 
 #content {
-	position: relative;
+  position: relative;
 }
 
 .main-content {
-	margin-left:-10px;
-	margin-right:-10px;
+  margin-left: -10px;
+  margin-right: -10px;
 }
 
 .highlight {
-	background-color: yellow;
+  background-color: yellow;
 }
 
-.makelab-content-container{
-    /*margin-left: 40px;*/
-    /*margin-right: 40px;*/
-    max-width: 1400px;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
+.makelab-content-container {
+  /*margin-left: 40px;*/
+  /*margin-right: 40px;*/
+  max-width: 1400px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.youtube-player{
-    width: 100%;
-    height: 229px;
-    /*height: auto;*/
+.youtube-player {
+  width: 100%;
+  height: 229px;
+  /*height: auto;*/
 }
 
 .no-margin {
-    margin: 0px;
+  margin: 0;
 }
 
 .individual-project-listing {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 /* Custom navbar for filters */
+
 /* TODO: what is this doing here? Why is navbar stuff in here and not grayscale.css? Discuss with Lee */
+
 .breadcrumb {
-	background-color: transparent;
-	margin-bottom:0;
+  background-color: transparent;
+  margin-bottom: 0;
 }
 
 .navbar-custom {
-	/*font-family: helvetica-neue-lt;*/
-	font-family: roboto;
-	font-variant: normal;
-	/*text-transform: lowercase;*/
+  /*font-family: helvetica-neue-lt;*/
+  font-family: roboto;
+  font-variant: normal;
+  /*text-transform: lowercase;*/
 }
 
 .navbar-custom .navbar-brand {
-	font-weight: normal;
-	font-size: 14px;
+  font-weight: normal;
+  font-size: 14px;
 }
 
 .navbar-custom .nav li a {
-	padding-left: 10px;
-	padding-right: 10px;
-	font-size: 14px;
+  padding-left: 10px;
+  padding-right: 10px;
+  font-size: 14px;
 }
 
 .navbar-filter {
-    margin-bottom: 0;
-    min-height: 30px;
+  margin-bottom: 0;
+  min-height: 30px;
 }
 
 @media screen and (max-width: 767px) {
-      .navbar-nav {
-         float: left !important;
-      }
- }
+  .navbar-nav {
+    float: left !important;
+  }
+}
 
 .navbar-filter .navbar-nav > li > a {
-    /*color:#fff;*/
+  /*color:#fff;*/
 }
-.navbar-filter .navbar-nav > li > a:hover, .navbar-filter .navbar-nav > li > a:focus {
-    background-color: transparent;
-    color: #23527c;
-    text-decoration: underline;
+
+.navbar-filter .navbar-nav > li > a:hover,.navbar-filter .navbar-nav > li > a:focus {
+  background-color: transparent;
+  color: #23527c;
+  text-decoration: underline;
 }
-.navbar-filter .navbar-brand {
-    
-}
+
+
 
 .navbar-white {
-	background-color: white;
+  background-color: white;
 }
 
-.navbar-white .lab-text, .navbar-white a {
-	color: black;
+.navbar-white .lab-text,.navbar-white a {
+  color: black;
 }
 
 .well {
-	border-radius: 0 !important;
+  border-radius: 0 !important;
 }
 
 .easter-egg-show {
-    opacity: 1!important;
+  opacity: 1!important;
 }
 
 .easter-egg-hide {
-    opacity: 0;
+  opacity: 0;
 }
 
 .easter-egg-col {
-    position: relative;
+  position: relative;
 }
 
 .easter-egg-name {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .overlay-easter-egg {
-    bottom: 0;left: 0; top: 0; right: 0;
-    position: absolute;
-    opacity: 0;
+  bottom: 0;
+  left: 0;
+  top: 0;
+  right: 0;
+  position: absolute;
+  opacity: 0;
 }
 
-.project-gallery-col:hover .overlay-image{
-    opacity: 1;
+.project-gallery-col:hover .overlay-image {
+  opacity: 1;
 }
 
-.project-gallery-col:hover .project-gallery{
-    opacity: 0.7;
+.project-gallery-col:hover .project-gallery {
+  opacity: 0.7;
 }
 
 .project-people-col {
-    padding-left: 0px;
+  padding-left: 0;
 }
 
 .alumni-navbar {
-    padding-left: 0px;
+  padding-left: 0;
 }
 
 /**********************************************************/
+
 /************** Carousel (Banner) styles ******************/
-.carousel,
-.carousel-inner,
-.carousel-inner .item {
-	height: 500px;
+
+.carousel,.carousel-inner,.carousel-inner .item {
+  height: 500px;
 }
 
 .item {
@@ -205,491 +207,506 @@ h5 {
 }
 
 .carousel a {
-	color: hsl(195, 65%, 65%);
+  color: hsl(195, 65%, 65%);
 }
 
 .overlay {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: 10;
-	/*background-color: rgba(0, 0, 0, 0.55);*/
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  /*background-color: rgba(0, 0, 0, 0.55);*/
 }
 
 .page-title {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: 5;
-	pointer-events: none;
-	
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
+  pointer-events: none;
 }
 
 .shadow-right {
-	background: linear-gradient(335deg, rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 50%);
+  background: linear-gradient(335deg, rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 50%);
 }
 
 .shadow-left {
-	background: linear-gradient(65deg, rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 50%);
+  background: linear-gradient(65deg, rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 50%);
 }
 
 .fill {
-	width:100%;
-	height:500px;
-	background-position:center;
-	background-size:cover;
+  width: 100%;
+  height: 500px;
+  background-position: center;
+  background-size: cover;
 }
 
-.shortCarousel, .shortCarousel .carousel-inner, .shortCarousel .item {
-	height: 335px;
+.shortCarousel,.shortCarousel .carousel-inner,.shortCarousel .item {
+  height: 335px;
 }
 
 .shortCarousel .overlay {
-	vertical-align: bottom;
-	display: table-cell;
-	padding-top:0;
+  vertical-align: bottom;
+  display: table-cell;
+  padding-top: 0;
 }
 
-@media (max-width: 768px){
-    .overlay-title {
-	position: absolute;
-	/*height: 120px;
+@media (max-width: 768px) {
+  .overlay-title {
+    position: absolute;
+    /*height: 120px;
 	line-height: 120px;
 	width: 300px;
 	text-align: left;*/
-	font-weight: bold;
-	font-size: 36px;
-	margin-left: -3px;
-	bottom: 0;
-	color: #fff;
-	text-shadow: 0 1px 2px rgba(0,0,0,.6);
-    }
+    font-weight: bold;
+    font-size: 36px;
+    margin-left: -3px;
+    bottom: 0;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0,0,0,.6);
+  }
 }
 
-@media (min-width: 769px){
-    .overlay-title {
-	position: absolute;
-	/*height: 120px;
+@media (min-width: 769px) {
+  .overlay-title {
+    position: absolute;
+    /*height: 120px;
 	line-height: 120px;
 	width: 300px;
 	text-align: left;*/
-	font-weight: bold;
-	font-size: 72px;
-	margin-left: -3px;
-	bottom: 0;
-	color: #fff;
-	text-shadow: 0 1px 2px rgba(0,0,0,.6);
-    }    
+    font-weight: bold;
+    font-size: 72px;
+    margin-left: -3px;
+    bottom: 0;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0,0,0,.6);
+  }
 }
 
 .shortCarousel .fill {
-	width:100%;
-	height:335px;
-	background-position: center center;
-	background-size:cover;
+  width: 100%;
+  height: 335px;
+  background-position: center center;
+  background-size: cover;
 }
 
 .carousel-container {
-	height: 100%;
-	position: relative;
+  height: 100%;
+  position: relative;
 }
 
 .carousel-caption-left {
-	text-align: left;
-	right: auto;
-	left: 0;
-	bottom: 0;
-	/*padding-right: 20px;*/
-	padding-bottom: 55px;
-	padding-left: 15px;
-	width: 335px;
+  text-align: left;
+  right: auto;
+  left: 0;
+  bottom: 0;
+  /*padding-right: 20px;*/
+  padding-bottom: 55px;
+  padding-left: 15px;
+  width: 335px;
 }
 
 .carousel-caption-right {
-	text-align: right;
-	left: auto;
-	right: 0;
-	bottom: 0;
-	padding-right: 15px;
-	padding-bottom: 20px;
-	width: 300px;
+  text-align: right;
+  left: auto;
+  right: 0;
+  bottom: 0;
+  padding-right: 15px;
+  padding-bottom: 20px;
+  width: 300px;
 }
 
 .carousel-caption-title {
-	/*font-family: adelle-semibold;*/
-	font-size: 32px;
-	font-weight: 700;
+  /*font-family: adelle-semibold;*/
+  font-size: 32px;
+  font-weight: 700;
 }
 
 .carousel-caption-text {
-	/*font-family: adelle-light;*/
-	font-size: 16px;
+  /*font-family: adelle-light;*/
+  font-size: 16px;
 }
 
-@media (max-width: 989px){
-.carousel-indicators {
+@media (max-width: 989px) {
+  .carousel-indicators {
     display: none;
-}
+  }
 }
 
 /************************************************************/
+
 /************************ ARTIFACT STYLES *******************/
+
 /**** FOR THINGS LIKE PROJECTS, VIDEOS, TALKS, PAPERS *******/
 
-.to-appear-text{
-    font-style: italic;
+.to-appear-text {
+  font-style: italic;
 }
 
-.artifact-title{
-    font-size: 15px;
-    font-weight: 500;
-    margin: 3px 0px 0px 0px;
-    line-height: 1.3;
-	color: black;
+.artifact-title {
+  font-size: 15px;
+  font-weight: 500;
+  margin: 3px 0 0 0;
+  line-height: 1.3;
+  color: black;
 }
 
 .talk-column .pub-download-links {
-	opacity: 0;
+  opacity: 0;
 }
 
 .talk-column:hover .pub-download-links {
-	opacity: 1;
+  opacity: 1;
 }
 
 .pub-download-links {
-    font-size: 7pt;
-    color: gray;
-	margin: 0 20px 0 107px;
-	bottom: 0;
-    position: absolute;
-    border-top: 1px solid #dddddd;
+  font-size: 7pt;
+  color: gray;
+  margin: 0 20px 0 107px;
+  bottom: 0;
+  position: absolute;
+  border-top: 1px solid #dddddd;
 }
 
-.artifact-venue, .artifact-subtitle{
-    /*color: #7F7F7F;*/
-    font-size: 13px;
-    margin: 2px 0px 2px 0px;
+.artifact-venue {
+  /*color: #7F7F7F;*/
+  font-size: 13px;
+  margin: 2px 0 2px 0;
 }
 
-.artifact-authors, .artifact-subtitle2{
-    color: #7F7F7F;
-    font-size: 11px;
-	margin: 0;
+.artifact-authors {
+  color: #7F7F7F;
+  font-size: 11px;
+  margin: 0;
 }
 
-.artifact-authors a{
-    color: #7F7F7F;
+.artifact-authors a {
+  color: #7F7F7F;
 }
 
 .artifact-links {
-    color: #696969; /* RGB(105, 105, 105) */
-    font-size: small;
+  color: #696969;
+  /* RGB(105, 105, 105) */
+  font-size: small;
 }
 
-.artifact-links a{
-    color: #696969; /* RGB(105, 105, 105) */
-    font-size: small;
+.artifact-links a {
+  color: #696969;
+  /* RGB(105, 105, 105) */
+  font-size: small;
 }
 
-/* add this class to the container element for any images 
-   you would apply the zoom / darken effect to on hover */	
+/* add this class to the container element for any images
+   you would apply the zoom / darken effect to on hover */
+
 .artifact-thumbnail-hover {
-	position: relative;
-	overflow: hidden;
-}
-
-.artifact-thumbnail-hover img {
-	/* can uncomment these lines to change the origin of the zoom */
-	/*-webkit-transform-origin: top left;
-	transform-origin: top left;*/
+  position: relative;
+  overflow: hidden;
 }
 
 .artifact-thumbnail-hover:hover img {
-	-webkit-transform: scale(1.2);
-	transform: scale(1.2);
+  -webkit-transform: scale(1.2);
+  transform: scale(1.2);
 }
 
 .artifact-thumbnail-hover img {
-	-webkit-transition: 0.6s ease;
-	transition: 0.6s ease;
+  -webkit-transition: 0.6s ease;
+  transition: 0.6s ease;
 }
 
 .artifact-overlay {
-	position: absolute;
-	left: 0;
-	top: 0;
-	width: 100%;
-	height: 100%;
-	display: table;
-	
-	opacity: 0%;
-	-webkit-transition: 0.6s ease;
-	transition: 0.6s ease;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: table;
+  opacity: 0;
+  -webkit-transition: 0.6s ease;
+  transition: 0.6s ease;
 }
 
 .artifact-overlay:hover {
-	opacity: 100%;
-	background-color: rgba(0,0,0,0.5);
+  opacity: 1;
+  background-color: rgba(0,0,0,0.5);
 }
 
 .artifact-overlay-content {
-	width: 100%;
-	text-align: center;
-	font-size: x-large;
-	color: #fff;
-	display: none;
-	line-height: 50px;
+  width: 100%;
+  text-align: center;
+  font-size: x-large;
+  color: #fff;
+  display: none;
+  line-height: 50px;
 }
 
 .artifact-overlay-content a {
-	color: #fff;
-	border: 1px solid white;
-	border-radius: 3px;
-	padding: 5px;
-	margin: 4px;
+  color: #fff;
+  border: 1px solid white;
+  border-radius: 3px;
+  padding: 5px;
+  margin: 4px;
 }
 
 .artifact-overlay-content a:hover {
-	text-decoration: none;
-	color: #ddd;
+  text-decoration: none;
+  color: #ddd;
 }
 
 .artifact-overlay:hover>.artifact-overlay-content {
-	display: table-cell;
-	vertical-align: middle;
+  display: table-cell;
+  vertical-align: middle;
 }
 
 /***************************************************/
+
 /************* Makeability Lab footer **************/
 
-.makelab-footer{
-	background-color: #3797db;
-	color: white;
-	margin-top: 50px;
-	padding-top: 40px;
-	position: relative;
-	/*padding-bottom: 20px;*/
+.makelab-footer {
+  background-color: #3797db;
+  color: white;
+  margin-top: 50px;
+  padding-top: 40px;
+  position: relative;
+  /*padding-bottom: 20px;*/
 }
 
-.makelab-footer-row{
-	/*margin-top: 20px;*/
-	/*margin-bottom: 20px;*/
-	max-width: 1400px;
-    margin-left: auto;
-    margin-right: auto;
+.makelab-footer-row {
+  /*margin-top: 20px;*/
+  /*margin-bottom: 20px;*/
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.makelab-footer-affiliations{
-	background-color: black; /* should be same color as navbar header */
-	padding-right: 5px;
-	padding-left: 5px;
-	padding-top: 30px;
-	padding-bottom: 30px;
+.makelab-footer-affiliations {
+  background-color: black;
+  /* should be same color as navbar header */
+  padding-right: 5px;
+  padding-left: 5px;
+  padding-top: 30px;
+  padding-bottom: 30px;
 }
 
-.makelab-footer-affiliations-row{
-	max-width: 1300px;
-    margin-left: auto;
-    margin-right: auto;
-	display: flex;
-	justify-content: space-around;
-	align-items: center;
+.makelab-footer-affiliations-row {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
 }
 
-.makelab-footer-affiliation-logo{
-	/*height: 75px;*/
-	max-height: 30px;
-
-	/* Center content. See center-block in bootstrap.css */
-	display: block;
-  	margin-right: auto;
-  	margin-left: auto;
+.makelab-footer-affiliation-logo {
+  /*height: 75px;*/
+  max-height: 30px;
+  /* Center content. See center-block in bootstrap.css */
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
 }
 
-.makelab-footer-affiliation-col{
-	max-width: 18%;
-	margin: 0 5px;
+.makelab-footer-affiliation-col {
+  max-width: 18%;
+  margin: 0 5px;
 }
 
-.makelab-footer-col{
-	margin-top: 20px;
-	margin-bottom: 50px;
-	margin-right: 20px;
-	margin-left: 20px;
-	width: 21%;
+.makelab-footer-col {
+  margin: 20px 20px 50px 20px;
+  width: 21%;
 }
 
-.makelab-footer-recent-news{
-	width: 26%;
+.makelab-footer-recent-news {
+  width: 26%;
 }
 
-.makelab-footer-links{
-	width: 10%;
+.makelab-footer-links {
+  width: 10%;
 }
 
-.makelab-footer-col h1{
-	text-transform: uppercase;
-	font-weight: bold;
-	font-size: 16px;
-	margin: 0px;
-	padding: 0px;
+.makelab-footer-col h1 {
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 16px;
+  margin: 0;
+  padding: 0;
 }
 
 .makelab-footer-col ul {
-	list-style: none;
-	padding-left: 0;
-	/*margin-top: 5px;*/
+  list-style: none;
+  padding-left: 0;
+  /*margin-top: 5px;*/
 }
 
 .makelab-footer-col li {
-	margin-top: 5px;
-	color: white;
+  margin-top: 5px;
+  color: white;
 }
 
 .makelab-footer-col li.active {
-	font-weight: bold;
-	
+  font-weight: bold;
 }
 
-.makelab-footer-col a{
-	text-decoration: none;
+.makelab-footer-col a {
+  text-decoration: none;
 }
-.makelab-footer-col a:hover{
-}
+
+
 
 .makelab-footer-col a:link {
-	color: white;
+  color: white;
 }
 
 .makelab-footer-col a:visited {
-	color: white;
+  color: white;
 }
 
-.makelab-footer-connect-logo{
-	max-height: 18px;
+.makelab-footer-connect-logo {
+  max-height: 18px;
 }
 
-.makelab-footer-connect-links ul{
-	list-style-type: none;
-    margin: 0;
-    padding: 10px 0;
+.makelab-footer-connect-links ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 10px 0;
 }
 
 .makelab-footer-connect-links li {
-    display: inline;
-    margin-right: 10px;
+  display: inline;
+  margin-right: 10px;
 }
 
-.makelab-footer-connect-links a{
-	text-decoration: none;
+.makelab-footer-connect-links a {
+  text-decoration: none;
 }
 
-
-.makelab-footer-logo{
-	max-width: 180px;
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
+.makelab-footer-logo {
+  max-width: 180px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.makelab-footer-connect-links-mobile{
-	display: none;
+.makelab-footer-connect-links-mobile {
+  display: none;
 }
 
 /** RESPONSIVE FOOTER FOR TABLET *******/
+
 /** Author: Dhruv Jain ****************/
+
 /** Date: Nov 9, 2018 *****************/
-@media screen and (max-width: 1040px) {  
-		.makelab-footer-col {
-			width: 28%;
-		}
-		.makelab-footer-recent-news {
-			display: none;
-		}
+
+@media screen and (max-width: 1040px) {
+  .makelab-footer-col {
+    width: 28%;
+  }
+
+  .makelab-footer-recent-news {
+    display: none;
+  }
 }
+
 /*** RESPONSIVE FOOTER FOR TABLET ENDS **/
 
 /** RESPONSIVE FOOTER FOR BETW. PHONE-TABLET *******/
+
 /** Author: Dhruv Jain ****************/
+
 /** Date: Nov 9, 2018 *****************/
+
 @media screen and (max-width: 770px) {
-		.makelab-footer-col {
-			width: 35%;
-		}  
-		.makelab-footer-links{
-			display: none;
-		}
+  .makelab-footer-col {
+    width: 35%;
+  }
+
+  .makelab-footer-links {
+    display: none;
+  }
 }
+
 /*** RESPONSIVE FOOTER FOR BETW. PHONE-TABLET ENDS **/
 
 /** RESPONSIVE FOOTER FOR PHONE *******/
+
 /** Author: Dhruv Jain ****************/
+
 /** Date: Nov 7, 2018 *****************/
-@media screen and (max-width: 550px) { 
-		.makelab-footer-links{
-			display: initial;
-		}
-        .makelab-footer-col {
-			width: 75%;
-			float: left;
-			margin-bottom: 0.5em;
-		}
-		.makelab-footer-recent-news {
-			display: none;
-		}
-		.makelab-footer-connect-links{
-			display: none;
-		}
-		.makelab-footer-logo{
-			float: left;
-			width: 100%;
-			max-width: 180px;
-		}
-		
-		.makelab-footer-connect-links-mobile{
-			display: initial;
-		}
-		.makelab-footer-connect-links-mobile ul{
-			list-style-type: none;
-			margin-top: 2em;
-			padding: 10px 0;
-		}
-		.makelab-footer-connect-links-mobile li {
-			display: inline;
-			margin-right: 10px;
-		}
-		.makelab-footer-connect-links-mobile a{
-			text-decoration: none;
-		}
 
-		#uw-cse-footer-icon, #umd-cse-footer-icon {
-			display: none;
-		}
+@media screen and (max-width: 550px) {
+  .makelab-footer-links {
+    display: initial;
+  }
 
-		#uw-footer-icon img {
-			content:url("/static/website/img/logos/uw_solo_white_w_logo.png");
-		}
+  .makelab-footer-col {
+    width: 75%;
+    float: left;
+    margin-bottom: 0.5em;
+  }
 
-		#umd-footer-icon img {
-			content:url("/static/website/img/logos/umd_logo_white.png");
-		}
+  .makelab-footer-recent-news {
+    display: none;
+  }
+
+  .makelab-footer-connect-links {
+    display: none;
+  }
+
+  .makelab-footer-logo {
+    float: left;
+    width: 100%;
+    max-width: 180px;
+  }
+
+  .makelab-footer-connect-links-mobile {
+    display: initial;
+  }
+
+  .makelab-footer-connect-links-mobile ul {
+    list-style-type: none;
+    margin-top: 2em;
+    padding: 10px 0;
+  }
+
+  .makelab-footer-connect-links-mobile li {
+    display: inline;
+    margin-right: 10px;
+  }
+
+  .makelab-footer-connect-links-mobile a {
+    text-decoration: none;
+  }
+
+  #uw-cse-footer-icon,  #umd-cse-footer-icon {
+    display: none;
+  }
+
+  #uw-footer-icon img {
+    content: url("/static/website/img/logos/uw_solo_white_w_logo.png");
+  }
+
+  #umd-footer-icon img {
+    content: url("/static/website/img/logos/umd_logo_white.png");
+  }
 }
+
 /*** RESPONSIVE FOOTER FOR PHONE ENDS **/
 
-
 /**************************************/
-/************ LINE CLAMPING ***********/
-/* TODO: change this to line-clamp1 for one line clamping */
-.line-clamp-one-line {
-    text-overflow: ellipsis;
 
-    /* Required for text-overflow to do anything */
-    white-space: nowrap;
-    overflow: hidden;
+/************ LINE CLAMPING ***********/
+
+/* TODO: change this to line-clamp1 for one line clamping */
+
+.line-clamp-one-line {
+  text-overflow: ellipsis;
+  /* Required for text-overflow to do anything */
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 /**
@@ -699,31 +716,33 @@ h5 {
  */
 
 /* TODO: consider changing the name to line-clamp2 to indicate that the line clamp amount is 2 lines */
-@supports (-webkit-line-clamp: 2) {
-    .line-clamp {
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-    }
 
-    .line-clamp:after {
-        display: none;
-    }
+@supports (-webkit-line-clamp: 2) {
+  .line-clamp {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .line-clamp:after {
+    display: none;
+  }
 }
 
 /* Clamps three lines */
-@supports (-webkit-line-clamp: 3) {
-    .line-clamp3 {
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-    }
 
-    .line-clamp3:after {
-        display: none;
-    }
+@supports (-webkit-line-clamp: 3) {
+  .line-clamp3 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+  }
+
+  .line-clamp3:after {
+    display: none;
+  }
 }
 
 /*!
@@ -731,72 +750,68 @@ h5 {
  * From: https://stackoverflow.com/a/22799354
  */
 
-.col-xs-5ths,
-.col-sm-5ths,
-.col-md-5ths,
-.col-lg-5ths {
-    position: relative;
-    min-height: 1px;
-    padding-right: 10px;
-    padding-left: 10px;
+.col-xs-5ths,.col-sm-5ths,.col-md-5ths,.col-lg-5ths {
+  position: relative;
+  min-height: 1px;
+  padding-right: 10px;
+  padding-left: 10px;
 }
 
-.col-xs-4-5ths,
-.col-sm-4-5ths,
-.col-md-4-5ths,
-.col-lg-4-5ths {
-    position: relative;
-    min-height: 1px;
-    padding-right: 10px;
-    padding-left: 10px;
+.col-xs-4-5ths,.col-sm-4-5ths,.col-md-4-5ths,.col-lg-4-5ths {
+  position: relative;
+  min-height: 1px;
+  padding-right: 10px;
+  padding-left: 10px;
 }
 
 .col-xs-5ths {
-    width: 20%;
-    float: left;
+  width: 20%;
+  float: left;
 }
 
 .col-xs-4-5ths {
-    width: 80%;
-    float: left;
+  width: 80%;
+  float: left;
 }
 
 @media (max-width: 550px) {
-	.talk-column .pub-download-links {
-		opacity: 1;
-	}
+  .talk-column .pub-download-links {
+    opacity: 1;
+  }
 }
 
 @media (min-width: 768px) {
-    .col-sm-5ths {
-        width: 20%;
-        float: left;
-    }
-    .col-sm-4-5ths {
-        width: 80%;
-        float: left;
-    }
+  .col-sm-5ths {
+    width: 20%;
+    float: left;
+  }
 
+  .col-sm-4-5ths {
+    width: 80%;
+    float: left;
+  }
 }
 
 @media (min-width: 992px) {
-    .col-md-5ths {
-        width: 20%;
-        float: left;
-    }
-    .col-md-4-5ths {
-        width: 80%;
-        float: left;
-    }
+  .col-md-5ths {
+    width: 20%;
+    float: left;
+  }
+
+  .col-md-4-5ths {
+    width: 80%;
+    float: left;
+  }
 }
 
 @media (min-width: 1200px) {
-    .col-lg-5ths {
-        width: 20%;
-        float: left;
-    }
-    .col-lg-4-5ths {
-        width: 80%;
-        float: left;
-    }
+  .col-lg-5ths {
+    width: 20%;
+    float: left;
+  }
+
+  .col-lg-4-5ths {
+    width: 80%;
+    float: left;
+  }
 }

--- a/website/static/website/css/bignews.css
+++ b/website/static/website/css/bignews.css
@@ -1,55 +1,47 @@
-.big-news-image {
-    
-}
-
 .content-container {
-    margin-top: 25px;
+  margin-top: 25px;
 }
 
 .big-news-title {
-    font-weight: bold;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin: 0 auto;
-    width: 100%;
+  font-weight: bold;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .big-news-author {
-    font-size: 18px;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin-top: 25px;
-    width: 100%;
+  font-size: 18px;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin-top: 25px;
+  width: 100%;
 }
 
 .big-news-published {
-    font-size: 15px;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin-top: 25px;
-    width: 100%;
+  font-size: 15px;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin-top: 25px;
+  width: 100%;
 }
 
 .big-news-project {
-    font-size: 15px;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin-top: 25px;
-    width: 100%;
+  font-size: 15px;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin-top: 25px;
+  width: 100%;
 }
 
 .big-news-content {
-    font-size: 20px;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin-top: 25px;
-    width: 100%;
-}
-
-.main-content {
-
+  font-size: 20px;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin-top: 25px;
+  width: 100%;
 }
 
 .news-type-label {
-    padding-top: 0px;
+  padding-top: 0;
 }

--- a/website/static/website/css/carousel_fade.css
+++ b/website/static/website/css/carousel_fade.css
@@ -2,6 +2,7 @@
 Hack to make the carousel transition using fade instead of slide
 inspired from http://codepen.io/Rowno/pen/Afykb 
 */
+
 .carousel-fade .carousel-inner .item {
   opacity: 0;
   transition-property: opacity;
@@ -11,15 +12,13 @@ inspired from http://codepen.io/Rowno/pen/Afykb
   opacity: 1;
 }
 
-.carousel-fade .carousel-inner .active.left,
-.carousel-fade .carousel-inner .active.right {
+.carousel-fade .carousel-inner .active.left,.carousel-fade .carousel-inner .active.right {
   left: 0;
   opacity: 0;
   z-index: 1;
 }
 
-.carousel-fade .carousel-inner .next.left,
-.carousel-fade .carousel-inner .prev.right {
+.carousel-fade .carousel-inner .next.left,.carousel-fade .carousel-inner .prev.right {
   opacity: 1;
 }
 
@@ -31,24 +30,23 @@ inspired from http://codepen.io/Rowno/pen/Afykb
 WHAT IS NEW IN 3.3: "Added transforms to improve carousel performance in modern browsers."
 now override the 3.3 new styles for modern browsers & apply opacity
 */
+
 @media all and (transform-3d), (-webkit-transform-3d) {
-    .carousel-fade .carousel-inner > .item.next,
-    .carousel-fade .carousel-inner > .item.active.right {
-      opacity: 0;
-      -webkit-transform: translate3d(0, 0, 0);
-              transform: translate3d(0, 0, 0);
-    }
-    .carousel-fade .carousel-inner > .item.prev,
-    .carousel-fade .carousel-inner > .item.active.left {
-      opacity: 0;
-      -webkit-transform: translate3d(0, 0, 0);
-              transform: translate3d(0, 0, 0);
-    }
-    .carousel-fade .carousel-inner > .item.next.left,
-    .carousel-fade .carousel-inner > .item.prev.right,
-    .carousel-fade .carousel-inner > .item.active {
-      opacity: 1;
-      -webkit-transform: translate3d(0, 0, 0);
-              transform: translate3d(0, 0, 0);
-    }
+  .carousel-fade .carousel-inner > .item.next,  .carousel-fade .carousel-inner > .item.active.right {
+    opacity: 0;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+
+  .carousel-fade .carousel-inner > .item.prev,  .carousel-fade .carousel-inner > .item.active.left {
+    opacity: 0;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+
+  .carousel-fade .carousel-inner > .item.next.left,  .carousel-fade .carousel-inner > .item.prev.right,  .carousel-fade .carousel-inner > .item.active {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
 }

--- a/website/static/website/css/faq.css
+++ b/website/static/website/css/faq.css
@@ -1,27 +1,27 @@
 .faq {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .faq ul#questions-list {
-    padding: 0;
-    list-style-type: none;
-    margin: 0;
+  padding: 0;
+  list-style-type: none;
+  margin: 0;
 }
 
 .faq ul#questions-list li {
-    padding: 10px 0;
-    border-bottom: 1px solid #ddd;
+  padding: 10px 0;
+  border-bottom: 1px solid #ddd;
 }
 
-.faq-item:before, .topic-items-active {
-    display: block!important;
+.faq-item:before,.topic-items-active {
+  display: block!important;
 }
 
 .faq-item:before {
-    content: " ";
-    height: 44px;
-    margin-top: -44px;
-    visibility: hidden;
+  content: " ";
+  height: 44px;
+  margin-top: -44px;
+  visibility: hidden;
 }
 
 html {
@@ -29,39 +29,39 @@ html {
 }
 
 .permalink-icon {
-    height: 18px;
-    opacity: 0;
-    -webkit-transition: opacity 200ms ease-in-out;
-    transition: opacity 200ms ease-in-out;
+  height: 18px;
+  opacity: 0;
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
 }
 
 .plusminus {
-    float: right;
-    font-size: 18px;
+  float: right;
+  font-size: 18px;
 }
 
 .question {
-    font-size: 25px;
+  font-size: 25px;
 }
 
 .question:hover .permalink-icon {
-    opacity: 1;
+  opacity: 1;
 }
 
 .subtopics {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height .5s ease-out, padding .5s ease-out;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height .5s ease-out, padding .5s ease-out;
 }
 
 .subtopics-active {
-    max-height: 480px!important;
+  max-height: 480px!important;
 }
 
-.topic, .plusminus {
-    cursor: pointer;
+.topic,.plusminus {
+  cursor: pointer;
 }
 
 .topic-items {
-    display: none;
+  display: none;
 }

--- a/website/static/website/css/fixed_side_bar.css
+++ b/website/static/website/css/fixed_side_bar.css
@@ -1,49 +1,49 @@
 .shortTextbox {
-	width: 100%;
+  width: 100%;
 }
 
 .filter-selected {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 #fixed-side-bar {
-	margin-left: 15px;
-	margin-top: 85px;
-	width: 125px;
-	left:0;
-	top:-60px;
-	/*font-family: adelle-light;*/
-	text-align: right;
-	position:absolute;
-	font-size: small;
+  margin-left: 15px;
+  margin-top: 85px;
+  width: 125px;
+  left: 0;
+  top: -60px;
+  /*font-family: adelle-light;*/
+  text-align: right;
+  position: absolute;
+  font-size: small;
 }
 
 #fixed-side-bar h1 {
-	font-size: 14px;
-	margin-bottom:0;
-	padding-bottom:0;
-	font-weight: regular;
+  font-size: 14px;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  font-weight: normal;
 }
 
 #filter-bar li {
-	text-decoration: none;
-	font-size: 12px;
-	list-style: none;
-	cursor: pointer;
-	width: 100%;
+  text-decoration: none;
+  font-size: 12px;
+  list-style: none;
+  cursor: pointer;
+  width: 100%;
 }
 
 #filter-bar .filter-group {
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
-	display: inline-block;
-	width: 105px;
-	vertical-align: middle;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  display: inline-block;
+  width: 105px;
+  vertical-align: middle;
 }
 
 #filter-bar .filter-group-count {
-	display: inline-block;
-	width: 20px;
-	vertical-align: middle;
+  display: inline-block;
+  width: 20px;
+  vertical-align: middle;
 }

--- a/website/static/website/css/fixed_side_bar.css
+++ b/website/static/website/css/fixed_side_bar.css
@@ -22,7 +22,6 @@
   font-size: 14px;
   margin-bottom: 0;
   padding-bottom: 0;
-  font-weight: normal;
 }
 
 #filter-bar li {

--- a/website/static/website/css/grayscale.css
+++ b/website/static/website/css/grayscale.css
@@ -3,129 +3,128 @@
  * The code below is based on the Grayscale Bootstrap Theme (http://startbootstrap.com)
  * Only the navbar styles were preserved and even then some of these styles have been modified
  */
+
 .navbar-custom {
-    margin-bottom: 0;
-    border-bottom: 1px solid rgba(255,255,255,.3);
-    text-transform: uppercase;
-    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    background-color: #000;
-    min-height: 44px;
+  margin-bottom: 0;
+  border-bottom: 1px solid rgba(255,255,255,.3);
+  text-transform: uppercase;
+  font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  background-color: #000;
+  min-height: 44px;
 }
 
-.navbar-custom .lab-text{
-    display: inline;
-    vertical-align: text-top;
+.navbar-custom .lab-text {
+  display: inline;
+  vertical-align: text-top;
 }
 
 .navbar-custom .navbar-brand>img {
-    display: inline;
+  display: inline;
 }
 
 .navbar-custom .navbar-brand {
-    font-weight: 700;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    padding-left: 15px;
-    height: auto;
+  font-weight: 700;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 15px;
+  height: auto;
 }
 
 .navbar-custom .navbar-brand:focus {
-    outline: 0;
+  outline: 0;
 }
 
 .navbar-custom .navbar-brand .navbar-toggle {
-    padding: 4px 6px;
-    font-size: 16px;
-    color: #fff;
+  padding: 4px 6px;
+  font-size: 16px;
+  color: #fff;
 }
 
-.navbar-custom .navbar-brand .navbar-toggle:focus,
-.navbar-custom .navbar-brand .navbar-toggle:active {
-    outline: 0;
+.navbar-custom .navbar-brand .navbar-toggle:focus,.navbar-custom .navbar-brand .navbar-toggle:active {
+  outline: 0;
 }
 
-.navbar-custom a, .navbar-custom .nav li.active a:hover, .navbar-toggle {
-    color: #fff;
+.navbar-custom a,.navbar-custom .nav li.active a:hover,.navbar-toggle {
+  color: #fff;
 }
 
 .navbar-custom .nav li a {
-    -webkit-transition: background .3s ease-in-out;
-    -moz-transition: background .3s ease-in-out;
-    transition: background .3s ease-in-out;
+  -webkit-transition: background .3s ease-in-out;
+  -moz-transition: background .3s ease-in-out;
+  transition: background .3s ease-in-out;
 }
 
-.navbar-custom .nav li a:hover, .navbar-white .nav li a:hover {
-    outline: 0;
-    background-color: transparent;
+.navbar-custom .nav li a:hover,.navbar-white .nav li a:hover {
+  outline: 0;
+  background-color: transparent;
 }
 
 .navbar-custom .nav li a:hover {
-    color: rgba(255,255,255,.8);
+  color: rgba(255,255,255,.8);
 }
 
 .navbar-white .nav li a:hover {
-    color: rgba(0,0,0,.6);
+  color: rgba(0,0,0,.6);
 }
 
-.navbar-custom .nav li a:focus,
-.navbar-custom .nav li a:active {
-    outline: 0;
-    background-color: transparent;
+.navbar-custom .nav li a:focus,.navbar-custom .nav li a:active {
+  outline: 0;
+  background-color: transparent;
 }
 
 .navbar-custom .nav li.active {
-    outline: 0;
+  outline: 0;
 }
 
 .navbar-custom .nav li.active a {
-    /*background-color: rgba(255,255,255,.3);*/
-    font-weight: bold;
-    /*font-family: helvetica-neue-lt-bold;*/
-    font-family: roboto-bold;
+  /*background-color: rgba(255,255,255,.3);*/
+  font-weight: bold;
+  /*font-family: helvetica-neue-lt-bold;*/
+  font-family: roboto-bold;
 }
 
 .navbar-white .navbar-brand img {
-    content:url("/static/website/img/logos/makelab_logo_black_no_text_100x67.png");
+  content: url("/static/website/img/logos/makelab_logo_black_no_text_100x67.png");
 }
 
 .navbar-white .navbar-toggle {
-    color: black;
+  color: black;
 }
 
-@media(min-width:789px) {
-    .navbar-custom {
-        /*padding: 5px 0;*/
-        /*padding-bottom: 10px;*/
-        border-bottom: 0;
-        letter-spacing: 1px;
-        /*background: 0 0;*/
-        /*background: linear-gradient(180deg, rgba(0,0,0,0.8), rgba(0,0,0,0.5) 60%, rgba(0,0,0,0));*/
-        background: rgba(0,0,0,0.6);
-        -webkit-transition: background .5s ease-in-out,padding .5s ease-in-out;
-        -moz-transition: background .5s ease-in-out,padding .5s ease-in-out;
-        transition: background .5s ease-in-out,padding .5s ease-in-out;
-    }
+@media (min-width:789px) {
+  .navbar-custom {
+    /*padding: 5px 0;*/
+    /*padding-bottom: 10px;*/
+    border-bottom: 0;
+    letter-spacing: 1px;
+    /*background: 0 0;*/
+    /*background: linear-gradient(180deg, rgba(0,0,0,0.8), rgba(0,0,0,0.5) 60%, rgba(0,0,0,0));*/
+    background: rgba(0,0,0,0.6);
+    -webkit-transition: background .5s ease-in-out,padding .5s ease-in-out;
+    -moz-transition: background .5s ease-in-out,padding .5s ease-in-out;
+    transition: background .5s ease-in-out,padding .5s ease-in-out;
+  }
 
-    .navbar-custom.top-nav-collapse {
-        padding: 0;
-        border-bottom: 1px solid rgba(255,255,255,.3);
-        background: #000;
-    }
+  .navbar-custom.top-nav-collapse {
+    padding: 0;
+    border-bottom: 1px solid rgba(255,255,255,.3);
+    background: #000;
+  }
 
-    .navbar-white.top-nav-collapse li a:hover {
-        color: rgba(255,255,255,.8);
-    }
+  .navbar-white.top-nav-collapse li a:hover {
+    color: rgba(255,255,255,.8);
+  }
 
-    .navbar-nav>li>a {
-        padding-top: 10px;
-        padding-bottom: 10px;
-    }
+  .navbar-nav>li>a {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
 
-    .navbar-white.top-nav-collapse .lab-text, .navbar-white.top-nav-collapse a {
-        color: white;
-    }
+  .navbar-white.top-nav-collapse .lab-text,  .navbar-white.top-nav-collapse a {
+    color: white;
+  }
 
-    .navbar-white.top-nav-collapse .navbar-brand img {
-        content:url("/static/website/img/logos/makelab_logo_white_no_text_100x67.png");
-    }
+  .navbar-white.top-nav-collapse .navbar-brand img {
+    content: url("/static/website/img/logos/makelab_logo_white_no_text_100x67.png");
+  }
 }

--- a/website/static/website/css/index.css
+++ b/website/static/website/css/index.css
@@ -1,192 +1,143 @@
-research-area-icon-label{
-    text-align: center;
+.research-area-icon-label {
+  text-align: center;
 }
 
 .news-listing {
-    display: none;
+  display: none;
 }
 
 @media only screen and (min-width: 600px) {
-    .news-listing{
-        display: inline;
-    }
+  .news-listing {
+    display: inline;
+  }
 }
 
 .research-area-icon-row img {
-    width: 100%;
+  width: 100%;
 }
 
-.research-area-icon-row{
-    padding-top: 20px;
-    padding-bottom: 20px
+.research-area-icon-row {
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 .research-area-icon-label {
-    width: 100%;
-    text-align: center;
+  width: 100%;
+  text-align: center;
 }
 
-.research-area-icon-col{
-    text-align: center;
+.research-area-icon-col {
+  text-align: center;
 }
 
-.section-header{
-    margin-top: 40px;
-    margin-bottom: 15px;
-    text-align: center;
-    font-size: 24px;
-    /*text-transform: uppercase;*/
+.section-header {
+  margin-top: 40px;
+  margin-bottom: 15px;
+  text-align: center;
+  font-size: 24px;
+  /*text-transform: uppercase;*/
 }
 
 .see-all-artifacts {
-    margin-top: 15px;
-    text-transform: uppercase;
-    text-align: right;
-    font-weight: 700;
+  margin-top: 15px;
+  text-transform: uppercase;
+  text-align: right;
+  font-weight: 700;
 }
 
-.project-column{
-    /*margin-top: 15px;*/
+.news_thumbnail_image {
+  width: 50px;
 }
 
-/*
-Just playing around wit hover effects
-.project-column:hover{*/
-    /*opacity: 0.5;*/
-    /*-webkit-transform: scale(1.05);*/
-    /*transform: scale(1.05);*/
-    /*overflow: hidden;*/
-/*}*/
-
-.news_thumbnail_image{
-    width: 50px;
+.pub-column {
+  /*no-op currently*/
+  height: 129px;
+  /* Had to fix height because of weird wrapping, see: https://stackoverflow.com/a/25682250 */
 }
 
-.pub-column{
-    /*no-op currently*/
-    height: 129px; /* Had to fix height because of weird wrapping, see: https://stackoverflow.com/a/25682250 */
-}
-
-.video{
-    /*width: 100%;*/
-}
-
-
-/*.section a{*/
-    /*color: black;*/
-/*}*/
-
-.talk-text{
-    margin-bottom: 20px;
-    vertical-align: top;
-    /*width:80%;*/
-    /*text-align: center;*/
+.talk-text {
+  margin-bottom: 20px;
+  vertical-align: top;
+  /*width:80%;*/
+  /*text-align: center;*/
 }
 
 .pub-thumbnail {
-    position: relative;
+  position: relative;
 }
 
 .pub-thumbnail-image {
-	border: 1px solid #dddddd;
-	width:90%;
-	margin:auto;
+  border: 1px solid #dddddd;
+  width: 90%;
+  margin: auto;
 }
 
 .pub-thumbnail-image2 {
-	border: 1px solid #dddddd;
+  border: 1px solid #dddddd;
 }
 
-.pub-text{
-    margin: 4px 9px 0px 9px;
-    vertical-align: top;
-    /*width:80%;*/
-    /*text-align: center;*/
+.pub-text {
+  margin: 4px 9px 0 9px;
+  vertical-align: top;
+  /*width:80%;*/
+  /*text-align: center;*/
 }
 
-.pub-to-appear-text{
-    font-style: italic;
+.pub-to-appear-text {
+  font-style: italic;
 }
 
 .pub-thumbnail-image-float-left {
-	border: 1px solid #dddddd;
-	width:25%;
-    float:left;
-    margin-right:5px;
-    /*position: absolute;*/
-    /*clip: rect(0px,100px,50px,0px);*/
+  border: 1px solid #dddddd;
+  width: 25%;
+  float: left;
+  margin-right: 5px;
+  /*position: absolute;*/
+  /*clip: rect(0px,100px,50px,0px);*/
 }
 
-.pub-text-float-left{
-    vertical-align: top;
+.pub-text-float-left {
+  vertical-align: top;
 }
 
-.pub-thumbnail-clipped {
-	border: 1px solid #dddddd;
-	width: 200px;
-    position: absolute;
-    clip: rect(0px,200px,100px,0px);
-    display: block;
-    min-height:100px;
+.talk2-thumbnail-image {
+  object-fit: cover;
+  width: 295.42px;
+  height: 166px;
 }
 
-.talk2-thumbnail{
-    /*width:250px;*/
+h1 {
+  text-transform: uppercase;
+  font-variant: normal;
 }
 
-.talk2-thumbnail-image{
-    object-fit: cover;
-    width: 295.42px;
-    height: 166px;
+#makelab-intro h1 {
+  text-align: center;
 }
 
-h1{
-    text-transform: uppercase;
-    font-variant: normal;
+#makelab-intro {
+  margin: 0;
+  padding: 0;
+  background-color: #eac446;
 }
 
-#makelab-intro h1{
-    text-align: center;
+.page-link {
+  margin: 0;
+  text-align: left;
 }
-
-#makelab-intro{
-    margin: 0px;
-    padding: 0px;
-    background-color: #eac446;
-}
-
-.page-link{
-    margin: 0;
-    text-align: left;
-}
-
 
 .landing-talk-fix {
-    /*min-width: 240px;*/
-    padding-left:0;
+  /*min-width: 240px;*/
+  padding-left: 0;
 }
 
-.landing-publications {
-    /*padding-left: 0;
-    padding-right: 0;*/
-}
-
-.landing-content {
-    /*padding-left: 0;*/
-}
-
-@media (min-width: 769px){
-    .landing-content {
-	padding-right: 80px;
-    }
+@media (min-width: 769px) {
+  .landing-content {
+    padding-right: 80px;
+  }
 }
 
 .content-container {
-    padding-left: 25px;
-    padding-right: 25px;
-}
-
-.row {
-    /*margin-left: 0;
-    margin-right: 0;*/
+  padding-left: 25px;
+  padding-right: 25px;
 }

--- a/website/static/website/css/member.css
+++ b/website/static/website/css/member.css
@@ -1,57 +1,57 @@
 .about-header {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .content-container {
-    margin-top: 25px;
+  margin-top: 25px;
 }
 
 .easter-egg-col img {
-    border-radius: 50%;
-    overflow: hidden;
+  border-radius: 50%;
+  overflow: hidden;
 }
 
 .easter-egg-col {
-    margin-bottom: 18px;
+  margin-bottom: 18px;
 }
-  
+
 .easter-egg-col:hover > img {
-    opacity: 0;
+  opacity: 0;
 }
 
 .easter-egg-col:hover .overlay-easter-egg {
-    opacity: 1;
+  opacity: 1;
 }
 
 .header-icon {
-    height: 25px;
-    width: 25px;
-    margin-right: 10px;
+  height: 25px;
+  width: 25px;
+  margin-right: 10px;
 }
 
 .header-link {
-    margin-top: 5px;
-    padding-left: 10px;
+  margin-top: 5px;
+  padding-left: 10px;
 }
 
 .icon-housing {
-    display: flex;
+  display: flex;
 }
 
 #makelab-recent-projects .individual-project-listing {
-    padding-left: 0;
-    padding-right: 30px;
+  padding-left: 0;
+  padding-right: 30px;
 }
 
 #makelab-recent-projects .news-type-label {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .member-title {
-    margin: 0;
+  margin: 0;
 }
 
-.person-title-text, .header-icon, .person-bio-text {
-    margin-top: 18px;
-    margin-bottom: 0;
+.person-title-text,.header-icon,.person-bio-text {
+  margin-top: 18px;
+  margin-bottom: 0;
 }

--- a/website/static/website/css/news-listing.css
+++ b/website/static/website/css/news-listing.css
@@ -1,136 +1,135 @@
 /* TODO: Cleanup the CSS in this file and start using artifact-title, artifact-venue, etc. from base.css */
+
 /* TODO: update--cleanup in progress. Note that any change here may impact publications.js and filterBar.js */
 
-@media (max-width: 768px){
-    .news-listing-list {
-	margin-top: 25px;
-    }
+@media (max-width: 768px) {
+  .news-listing-list {
+    margin-top: 25px;
+  }
 }
 
 .news-listing-pagination {
-	text-align: center;
-	margin: auto;
+  text-align: center;
+  margin: auto;
 }
 
 .news-listing-pagination ul {
-	display: inline-table;
+  display: inline-table;
 }
 
 .news-listing-pagination li {
-	display: inline;
-	font-size:20px;
-	padding:12px;
+  display: inline;
+  font-size: 20px;
+  padding: 12px;
 }
 
-
-@media (min-width: 769px){
-    .news-listing-list {
-	margin-top: 25px;
-    }
+@media (min-width: 769px) {
+  .news-listing-list {
+    margin-top: 25px;
+  }
 }
 
 /* TODO: do we need this .navbar? Need to investigate */
+
 .navbar {
-    width: 100%;
+  width: 100%;
 }
 
-
 .citation-links {
-    text-align: right;
-    margin-bottom: -5px;
+  text-align: right;
+  margin-bottom: -5px;
 }
 
 .news-listing-list h1 {
-	color: #7F7F7F;
-	font-size: 24px;
-	border-bottom: 1px solid #A6A6A6;
-	margin: 5px 0px 3px 0px;
-	padding-bottom: 1px;
+  color: #7F7F7F;
+  font-size: 24px;
+  border-bottom: 1px solid #A6A6A6;
+  margin: 5px 0 3px 0;
+  padding-bottom: 1px;
 }
 
 .news-listing-template {
-	padding-top:10px;
-	padding-bottom:10px;
-	font-size: 14px;
-	position:relative;
-	min-height: 170px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 14px;
+  position: relative;
+  min-height: 170px;
 }
 
 .news-listing-template p {
-	margin:0;
-	padding:0;
+  margin: 0;
+  padding: 0;
 }
 
 .news-listing-image-image {
-	border: 1px solid #dddddd;
-	width:100%;
-	max-width:135px;
-	margin:auto;
+  border: 1px solid #dddddd;
+  width: 100%;
+  max-width: 135px;
+  margin: auto;
 }
 
 .news-listing-info {
-	padding-bottom:20px; /* height of the downloads bar */
-	display:table-cell;
-	vertical-align: top;
-	width: 100%;
-	position: relative;
-
+  padding-bottom: 20px;
+  /* height of the downloads bar */
+  display: table-cell;
+  vertical-align: top;
+  width: 100%;
+  position: relative;
 }
 
-@media (max-width: 374px){
-    .news-listing-image {
-		display: none;
-    }
+@media (max-width: 374px) {
+  .news-listing-image {
+    display: none;
+  }
 }
 
-@media (min-width: 375px){
-    .news-listing-image {
-		width:120px;
-		min-width:120px;
-		display:table-cell;
-		vertical-align: top;
-		padding-right:10px;
-		position: relative;
-		top: 0px;
-		left: 0px;
-		z-index: 10;
-    }
+@media (min-width: 375px) {
+  .news-listing-image {
+    width: 120px;
+    min-width: 120px;
+    display: table-cell;
+    vertical-align: top;
+    padding-right: 10px;
+    position: relative;
+    top: 0;
+    left: 0;
+    z-index: 10;
+  }
 }
 
-
-@media (max-width: 768px){
-   .news-listing-id {
-		font-size: 10px;
-		color: #7F7F7F;
-		min-width: 40px;
-		display: table-cell;
-		vertical-align: top;
-		text-align: left;
-		padding-right: 10px;
-   }
+@media (max-width: 768px) {
+  .news-listing-id {
+    font-size: 10px;
+    color: #7F7F7F;
+    min-width: 40px;
+    display: table-cell;
+    vertical-align: top;
+    text-align: left;
+    padding-right: 10px;
+  }
 }
 
-@media (min-width: 769px){
-    .news-listing-id {
-		font-size: 10px;
-		color: #7F7F7F;
-		min-width: 40px;
-		display: table-cell;
-		vertical-align: top;
-		text-align: right;
-		padding-right: 10px;
-    }
+@media (min-width: 769px) {
+  .news-listing-id {
+    font-size: 10px;
+    color: #7F7F7F;
+    min-width: 40px;
+    display: table-cell;
+    vertical-align: top;
+    text-align: right;
+    padding-right: 10px;
+  }
 }
 
 .artifact-title {
-	color: #464D59;
-	font-size: 20px;
-	font-weight: 500;
-	word-wrap: break-word;
-	font-family: Raleway;
-	text-overflow: ellipsis;
+  color: #464D59;
+  font-size: 20px;
+  font-weight: 500;
+  word-wrap: break-word;
+  font-family: Raleway;
+  text-overflow: ellipsis;
 }
 
-.news-listing-content{
-    color: #444444;
+.news-listing-content {
+  color: #444444;
 }

--- a/website/static/website/css/news.css
+++ b/website/static/website/css/news.css
@@ -1,116 +1,107 @@
-.news_image{
-    float: left;
-    padding-right: 0px;
-    padding-bottom: 0px;
-    padding-top: 2px;
-    vertical-align: top;
+.news_image {
+  float: left;
+  padding-right: 0;
+  padding-bottom: 0;
+  padding-top: 2px;
+  vertical-align: top;
 }
 
-.news_content{
-    font-size: 11.5px;
-    font-family: adelle-regular;
-    padding-top: 5px;
-    padding-left: 0px;
-    padding-bottom: 0px;
-    margin: 0 auto;
-    width: 100%;
-    overflow: hidden;
-}
-
-.newstwitter-bar {
-    /*margin-left: -15px;*/
+.news_content {
+  font-size: 11.5px;
+  font-family: adelle-regular;
+  padding-top: 5px;
+  padding-left: 0;
+  padding-bottom: 0;
+  margin: 0 auto;
+  width: 100%;
+  overflow: hidden;
 }
 
 .news-well p {
-    margin: 0px;
-    
+  margin: 0;
 }
 
-.well{
-    background-color: white;
-    border: none;
-    box-shadow: none;
+.well {
+  background-color: white;
+  border: none;
+  box-shadow: none;
 }
 
 .news-column {
-    padding-left: 10px;
+  padding-left: 10px;
 }
 
-.twitter-row {
-}
 
-.twitter-timeline {
-    margin-left: -10px;
-}
 
 .content-clamp {
-      position: relative;
-      max-height: 8.6em; /* exactly six lines */
-    }
+  position: relative;
+  max-height: 8.6em;
+  /* exactly six lines */
+}
+
 .content-clamp:after {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 70%;
-    height: 1.4em;
-      
- }
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 70%;
+  height: 1.4em;
+}
 
 @supports (-webkit-line-clamp: 2) {
-    .content-clamp {
-        display: -webkit-box;
-        -webkit-line-clamp: 6;
-        -webkit-box-orient: vertical;  
-        max-height:8.6em; /* */
-        height: auto;
-    }
-    .content-clamp:after {
-        display: none;
-    }
+  .content-clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    max-height: 8.6em;
+    /* */
+    height: auto;
+  }
+
+  .content-clamp:after {
+    display: none;
+  }
 }
 
-
-.news_info{
-    padding-left: 50px;
-    padding-top: 0px;
-    width: 100%
+.news_info {
+  padding-left: 50px;
+  padding-top: 0;
+  width: 100%;
 }
 
-.news_title{
-    font-weight: bold;
-    font-size: 11px;
-    padding-top: 0px;
-    padding-left: 5px;
-    padding-bottom: 0px;
-    margin: 0 auto;
-    line-height: 13px;
-    width: 100%;
-    overflow: hidden;
+.news_title {
+  font-weight: bold;
+  font-size: 11px;
+  padding-top: 0;
+  padding-left: 5px;
+  padding-bottom: 0;
+  margin: 0 auto;
+  line-height: 13px;
+  width: 100%;
+  overflow: hidden;
 }
 
-
-.news_date{
-    padding-top: 3px;
-    font-size: 10px;
-    padding-left: 5px;
-    padding-bottom: 0px;
-    line-height: 100%;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+.news_date {
+  padding-top: 3px;
+  font-size: 10px;
+  padding-left: 5px;
+  padding-bottom: 0;
+  line-height: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.news_header{
-    padding-bottom: 0px;
+.news_header {
+  padding-bottom: 0;
 }
 
-.news_body{
-    padding-bottom: 20px
+.news_body {
+  padding-bottom: 20px;
 }
 
 .news-type-label {
-    padding-top: 20px;
-    text-align: left;
-    margin: 0 auto;
-    margin-bottom: 4px;
+  padding-top: 20px;
+  text-align: left;
+  margin: 0 auto;
+  margin-bottom: 4px;
 }

--- a/website/static/website/css/people.css
+++ b/website/static/website/css/people.css
@@ -1,9 +1,9 @@
 .fix-row-align {
-	margin-left: -10px;
-	margin-right: -10px;
+  margin-left: -10px;
+  margin-right: -10px;
 }
 
 .people-col {
-	padding-left: 0px;
-	padding-right: 20px;
+  padding-left: 0;
+  padding-right: 20px;
 }

--- a/website/static/website/css/project.css
+++ b/website/static/website/css/project.css
@@ -1,123 +1,123 @@
 .row-adjust-margins {
-    margin-left: -10px;
-    margin-right: -10px;
+  margin-left: -10px;
+  margin-right: -10px;
 }
 
 .people-col {
-    padding-left: 0;
+  padding-left: 0;
 }
 
 .people-row {
-    margin-right: -20px;
+  margin-right: -20px;
 }
 
 .info-title {
-    margin-left: 0px;
+  margin-left: 0;
 }
 
 .project-intro-content {
-    padding-right: 30px;
+  padding-right: 30px;
 }
 
-@media (max-width: 768px){
-    .video-about {
-	width: 100%;
-    }
+@media (max-width: 768px) {
+  .video-about {
+    width: 100%;
+  }
 }
 
-@media (min-width: 769px){
-    .video-about {
-	height: 300px;
-	width: 535px; /*1.78 * height*/
-    }
+@media (min-width: 769px) {
+  .video-about {
+    height: 300px;
+    width: 535px;
+    /*1.78 * height*/
+  }
 }
-
 
 .header-visual {
-    padding-right: 10px;
-    margin-left: 20px;
-    margin-bottom: 20px;
+  padding-right: 10px;
+  margin-left: 20px;
+  margin-bottom: 20px;
 }
 
 .content-container {
-    padding-left: 25px;
-    padding-right: 25px;
+  padding-left: 25px;
+  padding-right: 25px;
 }
 
 .no-margin {
-    padding: 0px;
+  padding: 0;
 }
 
 .people-col {
-    padding-left: 0px;
+  padding-left: 0;
 }
 
 .publication-template {
-    margin: 0px;
+  margin: 0;
 }
 
 .header-visual-title {
-    font-family: adelle-regular;
-	font-weight: bold;
-	color: #464D59;
-	font-size: 15px;
-	word-wrap: break-word;
-	text-overflow: ellipsis;
-	padding-top: 5px;
-	margin-bottom: 0px;
-	float: right;
-	max-width: 535px;
+  font-family: adelle-regular;
+  font-weight: bold;
+  color: #464D59;
+  font-size: 15px;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
+  padding-top: 5px;
+  margin-bottom: 0;
+  float: right;
+  max-width: 535px;
 }
 
 .header-visual-caption {
-    margin-top: 0px;
-    color: #7F7F7F;
-    float: right;
-    max-width: 535px;
+  margin-top: 0;
+  color: #7F7F7F;
+  float: right;
+  max-width: 535px;
 }
 
-
 .project-gallery {
-    width: 100%;
+  width: 100%;
 }
 
 .project-gallery-col {
-    padding: 0px;
-    margin: 0px;
+  padding: 0;
+  margin: 0;
 }
 
-
 .overlay-image {
-    bottom: 0;left: 0; top: 0; right: 0;
-    height: 100%;
-    width: 100%;
-    margin: auto;
-    position: absolute;
-    background: rgba(50, 50, 50, .7);
-    opacity:0;
-    line-height: 250px;
-    text-align:center;
+  bottom: 0;
+  left: 0;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 100%;
+  margin: auto;
+  position: absolute;
+  background: rgba(50, 50, 50, .7);
+  opacity: 0;
+  line-height: 250px;
+  text-align: center;
 }
 
 .image-gallery-caption {
-    color:white;
-    weight:bold;
-    font-size:1.8rem;
-    line-height: 1.5;
-    display: inline-block;
-    vertical-align: middle;
-    padding-left: 5%;
-    padding-right:5%;
+  color: white;
+  font-weight: bold;
+  font-size: 1.8rem;
+  line-height: 1.5;
+  display: inline-block;
+  vertical-align: middle;
+  padding-left: 5%;
+  padding-right: 5%;
 }
 
-
-.video-column, .talk-column {
-    padding-left: 0;
-    padding-right: 30px;
+.video-column,.talk-column {
+  padding-left: 0;
+  padding-right: 30px;
 }
 
-@media (max-width: 414px){
-    .recent-news, .quick-info {
-        display: none;
-    }
+@media (max-width: 414px) {
+  .recent-news,  .quick-info {
+    display: none;
+  }
 }

--- a/website/static/website/css/publications.css
+++ b/website/static/website/css/publications.css
@@ -1,183 +1,185 @@
 /* TODO: Cleanup the CSS in this file and start using artifact-title, artifact-venue, etc. from base.css */
+
 /* TODO: update--cleanup in progress. Note that any change here may impact publications.js and filterBar.js */
-@media only screen and (max-width: 600px){
-	.citation-link{
-		display: none;
-	}
+
+@media only screen and (max-width: 600px) {
+  .citation-link {
+    display: none;
+  }
 }
 
-
-@media (max-width: 768px){
-    .publication-list {
-	margin-top: 25px;
-    }
+@media (max-width: 768px) {
+  .publication-list {
+    margin-top: 25px;
+  }
 }
 
-@media (min-width: 769px){
-    .publication-list {
-	padding-left: 145px; /* should be greater than the filter-bar width */
-	margin-top: 25px;
-    }
+@media (min-width: 769px) {
+  .publication-list {
+    padding-left: 145px;
+    /* should be greater than the filter-bar width */
+    margin-top: 25px;
+  }
 }
 
 /* TODO: do we need this .navbar? Need to investigate */
+
 .navbar {
-    width: 100%;
+  width: 100%;
 }
 
 .citation-links {
-    text-align: right;
-    margin-bottom: -5px;
-	cursor: pointer;
+  text-align: right;
+  margin-bottom: -5px;
+  cursor: pointer;
 }
 
 .publication-list h1 {
-	color: #7F7F7F;
-	font-size: 24px;
-	border-bottom: 1px solid #A6A6A6;
-	margin: 5px 0px 3px 0px;
-	padding-bottom: 1px;
+  color: #7F7F7F;
+  font-size: 24px;
+  border-bottom: 1px solid #A6A6A6;
+  margin: 5px 0 3px 0;
+  padding-bottom: 1px;
 }
 
 .publication-template {
-	padding-top:10px;
-	padding-bottom:10px;
-	font-size: 14px;
-	position:relative;
-	min-height: 170px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 14px;
+  position: relative;
+  min-height: 170px;
 }
 
 .publication-template p {
-	margin:0;
-	padding:0;
+  margin: 0;
+  padding: 0;
 }
 
 .publication-thumbnail-image {
-	border: 1px solid #dddddd;
-	width:100%;
-	max-width:135px;
-	margin:auto;
+  border: 1px solid #dddddd;
+  width: 100%;
+  max-width: 135px;
+  margin: auto;
 }
 
 .publication-info {
-	padding-bottom:20px; /* height of the downloads bar */
-	display:table-cell;
-	vertical-align: top;
-	width: 100%;
-	position: relative;
-
+  padding-bottom: 20px;
+  /* height of the downloads bar */
+  display: table-cell;
+  vertical-align: top;
+  width: 100%;
+  position: relative;
 }
 
-@media (max-width: 374px){
-    .publication-thumbnail {
-		display: none;
-    }
+@media (max-width: 374px) {
+  .publication-thumbnail {
+    display: none;
+  }
 
-    .publication-award-banner {
-		display: none;
-    }
+  .publication-award-banner {
+    display: none;
+  }
 }
 
-@media (min-width: 375px){
-    .publication-thumbnail {
-		width:120px;
-		min-width:120px;
-		display:table-cell;
-		vertical-align: top;
-		padding-right:10px;
-		position: relative;
-		top: 0px;
-		left: 0px;
-		z-index: 10;
-    }
+@media (min-width: 375px) {
+  .publication-thumbnail {
+    width: 120px;
+    min-width: 120px;
+    display: table-cell;
+    vertical-align: top;
+    padding-right: 10px;
+    position: relative;
+    top: 0;
+    left: 0;
+    z-index: 10;
+  }
 
-    .publication-award-banner {
-		position: absolute;
-		top: 0px;
-		left: 0px;
-		height: 40px;
-		width: 40px;
-		z-index: 20;
-    }
+  .publication-award-banner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 40px;
+    width: 40px;
+    z-index: 20;
+  }
 }
 
-
-@media (max-width: 768px){
-   .publication-id {
-		font-size: 10px;
-		color: #7F7F7F;
-		min-width: 40px;
-		display: table-cell;
-		vertical-align: top;
-		text-align: left;
-		padding-right: 10px;
-   }
+@media (max-width: 768px) {
+  .publication-id {
+    font-size: 10px;
+    color: #7F7F7F;
+    min-width: 40px;
+    display: table-cell;
+    vertical-align: top;
+    text-align: left;
+    padding-right: 10px;
+  }
 }
 
-@media (min-width: 769px){
-    .publication-id {
-		font-size: 10px;
-		color: #7F7F7F;
-		min-width: 40px;
-		display: table-cell;
-		vertical-align: top;
-		text-align: right;
-		padding-right: 10px;
-    }
+@media (min-width: 769px) {
+  .publication-id {
+    font-size: 10px;
+    color: #7F7F7F;
+    min-width: 40px;
+    display: table-cell;
+    vertical-align: top;
+    text-align: right;
+    padding-right: 10px;
+  }
 }
 
 .artifact-title {
-	color: #464D59;
-	/*font-size: 16px;*/
-	font-weight: 500;
-	word-wrap: break-word;
-	text-overflow: ellipsis;
+  color: #464D59;
+  /*font-size: 16px;*/
+  font-weight: 500;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
 }
 
 .publication-stats {
-	color: #7F7F7F;
+  color: #7F7F7F;
 }
 
-.publication-award-text, .publication-award-icon {
-	color:#c25059;
+.publication-award-text,.publication-award-icon {
+  color: #c25059;
 }
 
 .publication-acceptance-rate {
-	font-style: bold;
+  font-style: bold;
 }
 
 .publication-to-appear-text {
-	font-style: italic;
+  font-style: italic;
 }
 
 .publication-keywords {
-	font-size: 11px;
-	color: #7F7F7F;
-	word-break: break-all;
+  font-size: 11px;
+  color: #7F7F7F;
+  word-break: break-all;
 }
 
 .publication-keyword {
-    word-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .publication-download {
-	position: absolute;
-	font-size: 12px;
-	border-top: 1px solid #dddddd;
-	width:100%;
-	height: 20px;
-	bottom:0;
-	right:0px;
-	margin-left:5px;
+  position: absolute;
+  font-size: 12px;
+  border-top: 1px solid #dddddd;
+  width: 100%;
+  height: 20px;
+  bottom: 0;
+  right: 0;
+  margin-left: 5px;
 }
 
 .publication-citation-link {
-	cursor:pointer;
+  cursor: pointer;
 }
 
 .award-icon {
-    borders: none;
-    width: 20px;
-    height: auto;
-    align: left;
+  borders: none;
+  width: 20px;
+  height: auto;
+  align: left;
 }

--- a/website/static/website/css/talks.css
+++ b/website/static/website/css/talks.css
@@ -1,169 +1,171 @@
 /* TODO: Cleanup the CSS in this file and start using artifact-title, artifact-venue, etc. from base.css */
 
-@media (max-width: 768px){
-    .talk-list {
-	margin-top: 25px;
-    }
+@media (max-width: 768px) {
+  .talk-list {
+    margin-top: 25px;
+  }
 }
 
-@media (min-width: 769px){
-    .talk-list {
-	padding-left: 145px; /* should be greater than the filter-bar width */
-	margin-top: 25px;
-    }
+@media (min-width: 769px) {
+  .talk-list {
+    padding-left: 145px;
+    /* should be greater than the filter-bar width */
+    margin-top: 25px;
+  }
 }
 
 .talk-list h1 {
-	color: #7F7F7F;
-	font-size: 24px;
-	border-bottom: 1px solid #A6A6A6;
-	margin: 5px 0px 3px 0px;
-	padding-bottom: 1px;
+  color: #7F7F7F;
+  font-size: 24px;
+  border-bottom: 1px solid #A6A6A6;
+  margin: 5px 0 3px 0;
+  padding-bottom: 1px;
 }
 
 .talk-template {
-	padding-top:10px;
-	padding-bottom:10px;
-	font-size: 12px;
-	position:relative;
-	min-height: 300px;
-	float: left;
-	/* added this in to fix the talk alignment temporarily, fixes the bootstrap alignment issues */
-	line-height: 1;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 12px;
+  position: relative;
+  min-height: 300px;
+  float: left;
+  /* added this in to fix the talk alignment temporarily, fixes the bootstrap alignment issues */
+  line-height: 1;
 }
 
-@media (max-width: 768px){
-    .talk-template-landing {
-		padding-top:10px;
-		padding-bottom:10px;
-		padding-right: 10px;
-		font-size: 12px;
-		position:relative;
-		margin: 0 auto;
-    }
+@media (max-width: 768px) {
+  .talk-template-landing {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    padding-right: 10px;
+    font-size: 12px;
+    position: relative;
+    margin: 0 auto;
+  }
 }
 
-@media (min-width: 769px){
-    .talk-template-landing {
-		padding-top:10px;
-		padding-bottom:10px;
-		padding-right: 10px;
-		font-size: 12px;
-		position:relative;
-		float: left;
-    }
+@media (min-width: 769px) {
+  .talk-template-landing {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    padding-right: 10px;
+    font-size: 12px;
+    position: relative;
+    float: left;
+  }
 }
 
 .group-template {
-	width:100%;
-	clear:left;
+  width: 100%;
+  clear: left;
 }
 
 .talk-template p {
-	margin:0;
-	padding:0;
+  margin: 0;
+  padding: 0;
 }
 
 .talk-template img {
-	border: 1px solid #dddddd;
-	/*max-width: 240px;*/
-	margin:auto;
+  border: 1px solid #dddddd;
+  /*max-width: 240px;*/
+  margin: auto;
 }
 
 .talk-info {
-	padding-bottom:20px; /* height of the downloads bar */
-	/*display:table-cell;*/
-	display:block;
-	vertical-align: top;
-	/*width: 240px;*/
-	position: relative;
-	margin-bottom:0;
+  padding-bottom: 20px;
+  /* height of the downloads bar */
+  /*display:table-cell;*/
+  display: block;
+  vertical-align: top;
+  /*width: 240px;*/
+  position: relative;
+  margin-bottom: 0;
 }
 
 .talk-thumbnail {
-	/*width: 240px;
+  /*width: 240px;
 	min-width: 240px;*/
-	height: 185px !important;
-	width: 10000px;
-	display:table-cell;
-	vertical-align: middle;
-	/*padding-right:10px;*/
+  height: 185px !important;
+  width: 10000px;
+  display: table-cell;
+  vertical-align: middle;
+  /*padding-right:10px;*/
 }
 
-.talk-thumbnail-image{
-    /*max-width: 240px;
+.talk-thumbnail-image {
+  /*max-width: 240px;
     max-height: 185px;*/
-    overflow: hidden;
-    width: 100%;
-    /*margin-right: 50px;*/
+  overflow: hidden;
+  width: 100%;
+  /*margin-right: 50px;*/
 }
 
 .talk-id {
-	font-size: 10px;
-	color: #7F7F7F;
-	min-width: 40px;
-	display: table-cell;
-	vertical-align: top;
-	text-align: right;
-	padding-right: 10px;
+  font-size: 10px;
+  color: #7F7F7F;
+  min-width: 40px;
+  display: table-cell;
+  vertical-align: top;
+  text-align: right;
+  padding-right: 10px;
 }
 
 .talk-title {
-	font-weight: bold;
-	color: #464D59;
-	font-size: 14px;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	/*width: 230px;*/
-	margin-bottom:4px;
+  font-weight: bold;
+  color: #464D59;
+  font-size: 14px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  /*width: 230px;*/
+  margin-bottom: 4px;
 }
 
 .talk-speakers {
-	text-overflow: ellipsis;
-	overflow: hidden;
-	height:1.5em;
-	/*width: 230px;*/
-	white-space:nowrap;
-	margin-bottom:0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 1.5em;
+  /*width: 230px;*/
+  white-space: nowrap;
+  margin-bottom: 0;
 }
 
 .talk-stats {
-	color: #7F7F7F;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	height:1.5em;
-	/*width: 230px;*/
-	white-space:nowrap;
-	margin-bottom:0;
+  color: #7F7F7F;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 1.5em;
+  /*width: 230px;*/
+  white-space: nowrap;
+  margin-bottom: 0;
 }
 
-.talk-award-text, .talk-award-icon {
-	color:#c25059;
+.talk-award-text,.talk-award-icon {
+  color: #c25059;
 }
 
 .talk-acceptance-rate {
-	font-style: bold;
+  font-weight: bold;
 }
 
 .talk-to-appear {
-	font-style: italic;
+  font-style: italic;
 }
 
 .talk-keywords {
-	font-size: 11px;
-	color: #7F7F7F;
+  font-size: 11px;
+  color: #7F7F7F;
 }
 
 .talk-download {
-	position: absolute;
-	font-size: 12px;
-	width:100%;
-	height: 20px;
-	bottom:0;
-	right:0px;
-	margin-left:5px;
+  position: absolute;
+  font-size: 12px;
+  width: 100%;
+  height: 20px;
+  bottom: 0;
+  right: 0;
+  margin-left: 5px;
 }
 
 .talk-citation-link {
-	cursor:pointer;
+  cursor: pointer;
 }


### PR DESCRIPTION
#664 
I removed any unused CSS and did a quick clean up of the CSS style. 

I know I recommend using UnCSS in my report. However, I found that UnCSS had some issues parsing our html because of Django. I instead used another tool called PurifyCSS and that did the trick. I then ran the CSS through CSS Lint to fix some of the basic styling errors.

All the CSS files have been modified to 2 space indents. This is a very common practice for CSS and recommended by [Harry Roberts](https://cssguidelin.es/#the-importance-of-a-styleguide) (he's included in my report), 
"At a very high-level, we want
    - two(2) space indents, no tabs;
    - 80character wide columns;
    - multi-line CSS;
    - meaningful use of whitespace.
But, as with anything, the specifics are somewhat irrelevant—consistency is key."

The next move would be installing a preprocessor and reorganizing the CSS files, but I know you want to talk more in depth about that.
