### PR TITLE
News title fix

### DIFF
--- a/website/templates/snippets/display_short_carousel_snippet.html
+++ b/website/templates/snippets/display_short_carousel_snippet.html
@@ -13,15 +13,15 @@
         <div class="container carousel-container">
             {#  | title is built into Django, how handy! see: https://stackoverflow.com/questions/14268342/make-the-first-letter-uppercase-inside-a-django-template #}
 {#            <div class="overlay-title">{{ request.path|title|slice:"1:"|slice:":-1" }}</div>#}
+            {% if not news.title %}
             <div class="overlay-title">
-                {% if news.title %}
-                    {{ news.title }}
-                {% elif page_title %}
+                {% if page_title %}
                     {{ page_title }}
                 {% else %}
                     {{ request.path|get_url_page|title }}
                 {% endif %}
             </div>
+            {% endif %}
         </div>
     </div>
     <!-- Wrapper for slides -->

--- a/website/templates/snippets/display_short_carousel_snippet.html
+++ b/website/templates/snippets/display_short_carousel_snippet.html
@@ -14,7 +14,9 @@
             {#  | title is built into Django, how handy! see: https://stackoverflow.com/questions/14268342/make-the-first-letter-uppercase-inside-a-django-template #}
 {#            <div class="overlay-title">{{ request.path|title|slice:"1:"|slice:":-1" }}</div>#}
             <div class="overlay-title">
-                {% if page_title %}
+                {% if news.title %}
+                    {{ news.title }}
+                {% elif page_title %}
                     {{ page_title }}
                 {% else %}
                     {{ request.path|get_url_page|title }}


### PR DESCRIPTION
#685 
As discussed in the issue, we've decided to remove the article title from the carousel banner for each article. 
Before:
![screen shot 2019-02-16 at 1 33 36 pm](https://user-images.githubusercontent.com/33988444/52905489-a499d300-31ef-11e9-847b-70fbe760c008.png)
After:
<img width="1285" alt="screen shot 2019-02-16 at 1 28 52 pm" src="https://user-images.githubusercontent.com/33988444/52905490-a794c380-31ef-11e9-8156-adce21d3cfb6.png">

