### PR TITLE
Django Update 2.1.7: fixes Sever Error (500)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Run `pip3 install -r requirements.txt` to install dependencies
 
-django==2.0.8
+django==2.1.7
 djangorestframework
 beautifulsoup4
 wand==0.4.4
 bibtexparser==1.0.1
 Pillow==5.2.0
 django-extensions==2.0.7
-django-image-cropping==1.1.0
+django-image-cropping==1.2.0
 django-sortedm2m==1.5.0
 easy_thumbnails==2.5
 xmltodict==0.11.0


### PR DESCRIPTION
#637 
#510 

Updates django to 2.1.7
Updates django-image-cropping to 1.2.0 to fix the error occurring in the admin panel for Django versions 2.1+.

I'm not sure why Github is highlighting `django-sortedm2m-filter-horizontal-widget` in its compare code feature, but it should remain unaffected.
