### PR TITLE
testing fix for missing images in lightbox test website

### DIFF
--- a/website/templates/snippets/display_project_gallery_lightbox.html
+++ b/website/templates/snippets/display_project_gallery_lightbox.html
@@ -9,7 +9,7 @@
     <div class="lightbox-content">
         {% for image in photos %}
             <div class="lightbox-slides" id="lightbox-slide{{ forloop.counter }}">
-                <img src="{% thumbnail image.picture 4000x4000 box=image.cropping crop detail %}" alt="{{image.alt_text}}">
+                <img src="{% thumbnail image.picture 1000x0 detail %}" alt="{{image.alt_text}}">
                 <div class="lightbox-caption">
                     <p>{{image.caption}}</p>
                 </div>


### PR DESCRIPTION
#692 
For some reason there is an error when finding the image sources on the test server even though the code worked on my local dev. I tried a slightly new line code to see if that will fix the issue. I'm going to merge right away so I can see if it's still broken.