### PR TITLE
Changes navbar on news page to white theme and removes banner

### DIFF
--- a/website/templates/snippets/display_short_carousel_snippet.html
+++ b/website/templates/snippets/display_short_carousel_snippet.html
@@ -13,7 +13,6 @@
         <div class="container carousel-container">
             {#  | title is built into Django, how handy! see: https://stackoverflow.com/questions/14268342/make-the-first-letter-uppercase-inside-a-django-template #}
 {#            <div class="overlay-title">{{ request.path|title|slice:"1:"|slice:":-1" }}</div>#}
-            {% if not news.title %}
             <div class="overlay-title">
                 {% if page_title %}
                     {{ page_title }}
@@ -21,7 +20,6 @@
                     {{ request.path|get_url_page|title }}
                 {% endif %}
             </div>
-            {% endif %}
         </div>
     </div>
     <!-- Wrapper for slides -->

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -135,7 +135,7 @@
 
     {% block navbar %}
         <!-- Navigation -->
-        <nav class="navbar navbar-custom {% with request.resolver_match.url_name as url_name %}{% if url_name == 'member' %}navbar-white{% endif %}{% endwith %} navbar-fixed-top"
+        <nav class="navbar navbar-custom {% with request.resolver_match.url_name as url_name %}{% if url_name == 'member' or url_name == 'news' %}navbar-white{% endif %}{% endwith %} navbar-fixed-top"
              role="navigation" >
             <div class="container-fluid" style="width:100%; max-width:1170px; margin:auto">
                 <div class = "row">

--- a/website/templates/website/news.html
+++ b/website/templates/website/news.html
@@ -12,7 +12,10 @@
 {% endblock %}
 
 {% block maincarousel %}
-    {% include "snippets/display_short_carousel_snippet.html" %}
+    <div style="min-height: 40px">&nbsp;
+        {# Uncomment the following if you want to have a carousel on the people page #}
+        {# {% include "snippets/display_short_carousel_snippet.html" %} #}
+    </div>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Changes navbar on news page to white theme and removes banner
Before:
<img width="1440" alt="53677646-44337880-3c68-11e9-8a15-88246909400a" src="https://user-images.githubusercontent.com/33988444/53686174-a926b700-3cd8-11e9-8069-47d6335284ff.png">

After:
<img width="1440" alt="53677637-21a15f80-3c68-11e9-8b0e-62394969e1c1" src="https://user-images.githubusercontent.com/33988444/53686171-a4fa9980-3cd8-11e9-8877-f40b1c4218fa.png">

![resize](https://user-images.githubusercontent.com/33988444/53686158-872d3480-3cd8-11e9-9e9f-31d4c3c12f2a.gif)
