### PR TITLE
Adds DOI link in citations

### DIFF
--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -59,6 +59,9 @@
 		} else if(pub.start_page && pub.end_page) {
 			text += pub.start_page + "&ndash;" + pub.end_page + ".";
 		}
+		if (pub.url !== "None") {
+   			text += "DOI: <a href='" + pub.url + "'>" + pub.url + "</a>";
+    	}
 	    text+="</div>";
 	    text+="<div id=\"bibtex-text\" style=\"display: none\">";
 	    text+="@inproceedings{"+pub.authors[0].last_name;
@@ -97,10 +100,7 @@
 		text+=" numpages = {"+String(parseInt(pub.page_num_end)-parseInt(pub.page_num_start))+"},<br/>";
 	    }
 	    if (pub.url && pub.url!="None" && pub.url!="tbd"){
-		text+=" url = {"+pub.url+"},<br/>";
-	    }
-	    if (pub.doi && pub.doi!="None" && pub.doi!="tbd"){
-		text+=" doi = {"+pub.doi+"},<br/>";
+		text+=" doi = {"+pub.url+"},<br/>";
 	    }
 	    if (pub.acmid && pub.acmid!="None" && pub.acmid!="tbd"){
 		text+=" acmid = {"+pub.acmid+"},<br/>";


### PR DESCRIPTION
#785 
Adds DOI link at the end of citation format and changes 'url' to 'doi' in bibtex format

With DOI
<img width="857" alt="screen shot 2019-03-05 at 10 56 47 am" src="https://user-images.githubusercontent.com/33988444/53829777-c0aeab80-3f35-11e9-87c4-b119f3c12332.png">
<img width="844" alt="screen shot 2019-03-05 at 10 56 53 am" src="https://user-images.githubusercontent.com/33988444/53829781-c2786f00-3f35-11e9-8478-22297722c5e2.png">
