### PR TITLE
Fixes minor DOI link bugs for Citation popover

### DIFF
--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -59,7 +59,7 @@
 		} else if(pub.start_page && pub.end_page) {
 			text += pub.start_page + "&ndash;" + pub.end_page + ". ";
 		}
-		if (pub.url !== "None" && pub.url !== "") {
+		if (pub.url && pub.url!="None" && pub.url!="tbd") {
    			text += "DOI: <a href='" + pub.url + "'>" + pub.url + "</a>";
     	}
 	    text+="</div>";

--- a/website/static/website/js/citationPopover.js
+++ b/website/static/website/js/citationPopover.js
@@ -55,11 +55,11 @@
 			if(pub.num_pages) {
 				text += pub.num_pages + " pages.";
 			}
-			text += " <i>To Appear</i>.";
+			text += " <i>To Appear</i>. ";
 		} else if(pub.start_page && pub.end_page) {
-			text += pub.start_page + "&ndash;" + pub.end_page + ".";
+			text += pub.start_page + "&ndash;" + pub.end_page + ". ";
 		}
-		if (pub.url !== "None") {
+		if (pub.url !== "None" && pub.url !== "") {
    			text += "DOI: <a href='" + pub.url + "'>" + pub.url + "</a>";
     	}
 	    text+="</div>";


### PR DESCRIPTION
Adds a space before DOI and fixes an if statement I test that believe lead to a DOI link with no url

Before:
<img width="1087" alt="Screen Shot 2019-03-20 at 1 41 25 PM" src="https://user-images.githubusercontent.com/33988444/54717629-d2877580-4b15-11e9-99bd-256bd4e9358e.png">
<img width="1071" alt="Screen Shot 2019-03-20 at 1 41 32 PM" src="https://user-images.githubusercontent.com/33988444/54717630-d2877580-4b15-11e9-814f-621d748b9289.png">

After:
<img width="1038" alt="Screen Shot 2019-03-20 at 1 40 30 PM" src="https://user-images.githubusercontent.com/33988444/54717624-d0251b80-4b15-11e9-9ad5-2e44ad56d671.png">
