### PR TITLE
Fixes HTML formatted news listing text previews

### DIFF
--- a/website/templates/website/member.html
+++ b/website/templates/website/member.html
@@ -116,7 +116,7 @@
                                         <!-- Truncation now uses a set number of lines which can be modified in news.css content-clamp class by changing -webkit-line-clamp -->
                                         <div class="news_content content-clamp">
                                             {% autoescape off %}
-                                                <p>{{ item.content }}</p>
+                                                <p>{{ item.content | removehtmltags }}</p>
                                             {% endautoescape %}
                                         </div>
                                     </div>

--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -8,6 +8,7 @@
 {% load staticfiles %}
 {% load thumbnail %}
 {% load cropping %}
+{% load ml_tags %}
 
 {% block stylesheets %}
 
@@ -81,7 +82,7 @@
                             <span class="news-listing-author-last">{{ n.short_date }}</span>
                     </p>
                     <p class="news-listing-content">
-                        <span class="line-clamp">{{ n.content | safe}}</span>
+                        <span class="line-clamp">{{ n.content | removehtmltags }}</span>
                         <a href="{% url 'website:news' news_id=n.id %}">[read more]</a>
                     </p>
                 </div>

--- a/website/templates/website/news.html
+++ b/website/templates/website/news.html
@@ -5,6 +5,7 @@
 {% load staticfiles %}
 {% load thumbnail %}
 {% load cropping %}
+{% load ml_tags %}
 
 {% block stylesheets %}
 <link rel="stylesheet" href="{% static 'website/css/news.css' %}">
@@ -83,7 +84,7 @@
 			<!-- Truncation now uses a set number of lines which can be modified in news.css content-clamp class by changing -webkit-line-clamp -->
 			<div class="news_content content-clamp">
 			    {% autoescape off %}
-			    <p>{{item.content}}</p>
+			    <p>{{ item.content | removehtmltags }}</p>
 			    {% endautoescape %}
 			</div>
 		    </div>

--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -104,7 +104,7 @@
 			<!-- Truncation now uses a set number of lines which can be modified in news.css content-clamp class by changing -webkit-line-clamp -->
 			<div class="news_content content-clamp">
 			    {% autoescape off %}
-			    <p>{{item.content}}</p>
+			    <p>{{ item.content  | removehtmltags }}</p>
 			    {% endautoescape %}
 			</div>
 		    </div>

--- a/website/templatetags/ml_tags.py
+++ b/website/templatetags/ml_tags.py
@@ -1,6 +1,7 @@
 # Read more about custom tags and filters here: https://docs.djangoproject.com/en/dev/howto/custom-template-tags/#writing-custom-template-filters
 from django import template
 from django.template.defaultfilters import stringfilter
+import re
 
 from django.template.defaulttags import register
 
@@ -24,3 +25,11 @@ def jsdate(d):
         return "new Date({0},{1},{2})".format(d.year, d.month - 1, d.day)
     except AttributeError:
         return 'undefined'
+
+ # Removes any HTML tags in String and returns new String
+@register.filter(name='removehtmltags')
+@stringfilter
+def removehtmltags(value):
+    cleanr = re.compile('<.*?>')
+    cleantext = re.sub(cleanr, '', value)
+    return cleantext


### PR DESCRIPTION
#618 
Adds a custom django template tag that removes any html from a string. I placed this tag anywhere that has a 'news text preview'. So that affects member page 'recent news', project page 'recent news', news listing page, and news 'recent news'.
Before:
<img width="1213" alt="Screen Shot 2019-03-20 at 2 31 36 PM" src="https://user-images.githubusercontent.com/33988444/54720500-d23ea880-4b1c-11e9-91bc-c824f62276d7.png">

After:
<img width="1214" alt="Screen Shot 2019-03-20 at 2 15 09 PM" src="https://user-images.githubusercontent.com/33988444/54720136-e7670780-4b1b-11e9-869c-d3fb2d06c143.png">
